### PR TITLE
Fix bugs related to vertical connections

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1356,7 +1356,6 @@ void connectInterfaces(
     final intf2ContainsIntf1 = intf2ToIntf1Path != null;
 
     if (intf1ContainsIntf2) {
-      // (intf1ToIntf2Path![1] as BridgeModule)
       intf1.module._pullUpInterfaceAndConnect(
         intf2,
         newIntfName: intf2PathNewName,
@@ -1365,7 +1364,7 @@ void connectInterfaces(
         exceptPorts: exceptPorts,
       );
     } else if (intf2ContainsIntf1) {
-      (intf2ToIntf1Path![1] as BridgeModule)._pullUpInterfaceAndConnect(
+      intf2.module._pullUpInterfaceAndConnect(
         intf1,
         newIntfName: intf1PathNewName,
         allowIntfUniquification: allowIntf1PathUniquification,

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1136,6 +1136,14 @@ void connectPorts(
     // e.g. feed-through
     throw RohdBridgeException(
         'Unhandled directionality and hierarchy of driver and receiver.');
+  } else if ((driverContainsReceiver || receiverContainsDriver) &&
+      (receiver.direction != driver.direction) &&
+      (receiver.direction != PortDirection.inOut &&
+          driver.direction != PortDirection.inOut)) {
+    throw RohdBridgeException(
+        'Vertical connections should have the same direction, but one of'
+        ' $driver and $receiver contains the other, but directions are'
+        ' ${driver.direction} and ${receiver.direction}, respectively.');
   } else {
     commonParent =
         findCommonParent(driverInstance, receiverInstance) as BridgeModule?;

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -566,7 +566,9 @@ class BridgeModule extends Module with SystemVerilog {
         .keys
         .toList(growable: false);
 
-    for (var i = path.length - 2; i >= 0; i--) {
+    for (var i = path.length - 2;
+        i > 0 || (i >= 0 && topToConnect == null);
+        i--) {
       // uniquify again along the path, in case of another conflict
       newIntf = newIntf.punchUpTo(
         path[i] as BridgeModule,
@@ -1288,6 +1290,14 @@ void connectInterfaces(
     // up and down case
     final commonParent = findCommonParent(intf1Instance, intf2Instance);
 
+    if (commonParent == intf1Instance || commonParent == intf2Instance) {
+      throw RohdBridgeException(
+          'Vertical connections should have the same role, but the common'
+          ' parent of $intf1Instance and $intf2Instance is $commonParent,'
+          ' but with mismatched roles ${intf1.role} and ${intf2.role},'
+          ' respectively.');
+    }
+
     if (commonParent == null) {
       throw RohdBridgeException('No common parent found between'
           ' $intf1Instance and $intf2Instance');
@@ -1338,7 +1348,8 @@ void connectInterfaces(
     final intf2ContainsIntf1 = intf2ToIntf1Path != null;
 
     if (intf1ContainsIntf2) {
-      (intf2ToIntf1Path![1] as BridgeModule)._pullUpInterfaceAndConnect(
+      // (intf1ToIntf2Path![1] as BridgeModule)
+      intf1.module._pullUpInterfaceAndConnect(
         intf2,
         newIntfName: intf2PathNewName,
         allowIntfUniquification: allowIntf2PathUniquification,
@@ -1346,7 +1357,7 @@ void connectInterfaces(
         exceptPorts: exceptPorts,
       );
     } else if (intf2ContainsIntf1) {
-      (intf1ToIntf2Path![1] as BridgeModule)._pullUpInterfaceAndConnect(
+      (intf2ToIntf1Path![1] as BridgeModule)._pullUpInterfaceAndConnect(
         intf1,
         newIntfName: intf1PathNewName,
         allowIntfUniquification: allowIntf1PathUniquification,

--- a/test/hierarchy_connection_test.dart
+++ b/test/hierarchy_connection_test.dart
@@ -101,9 +101,30 @@ void main() {
       });
     });
 
-    test('parent through mid to leaf connection', () async {});
+    test('parent through mid to leaf connection', () async {
+      await testConnection(matchDirection: true, (parent, child) {
+        final mid = BridgeModule('mid');
+        parent.addSubModule(mid..addSubModule(child));
+        connectPorts(child.port(portName2), parent.port(portName1));
+        return parent;
+      });
+    });
 
-    test('feed-through fails with error unsupported', () async {});
+    test('feed-through fails with error unsupported', () async {
+      try {
+        await testConnection(matchDirection: true, (leaf1, leaf2) {
+          final top = BridgeModule('top')
+            ..addSubModule(leaf1)
+            ..addSubModule(leaf2);
+          connectPorts(leaf2.port(portName2), leaf1.port(portName1));
+          return top;
+        });
+        fail('Should have thrown an exception');
+      } on RohdBridgeException catch (e) {
+        expect(e.message, contains('Unhandled direction'));
+        return;
+      }
+    });
   });
 
   test(

--- a/test/hierarchy_connection_test.dart
+++ b/test/hierarchy_connection_test.dart
@@ -15,29 +15,35 @@ import 'package:rohd_bridge/rohd_bridge.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('connect port from one leaf to another', () {
+  group('connect ports through hierarchy', () {
     const portName1 = 'myPort1';
     const portName2 = 'myPort2';
     const putVal = 0xab;
 
+    /// Expects mod2 drives mod1.
     void testConnection(
-        void Function(BridgeModule leaf1, BridgeModule leaf2)
-            makeConnectionsAndHier,
-        {dynamic matcher = 0xab}) {
-      final leaf1 = BridgeModule('leaf1')
-        ..createPort(portName1, PortDirection.input, width: 8);
-      final leaf2 = BridgeModule('leaf2')
+        void Function(
+          BridgeModule mod1,
+          BridgeModule mod2,
+        ) makeConnectionsAndHier,
+        {dynamic matcher = 0xab,
+        bool matchDirection = false}) {
+      final mod1 = BridgeModule('mod1')
+        ..createPort(portName1,
+            matchDirection ? PortDirection.output : PortDirection.input,
+            width: 8);
+      final mod2 = BridgeModule('mod2')
         ..createPort(portName2, PortDirection.output, width: 8);
 
-      makeConnectionsAndHier(leaf1, leaf2);
+      makeConnectionsAndHier(mod1, mod2);
 
       // NOTE: we did not attach leaf1 and leaf2 to top ports, so they will not
       // exist as submodules of top, but connection should still be made
 
       // check connection by putting a value on the wire at the source and
       // reading at destination
-      leaf2.output(portName2).put(putVal);
-      expect(leaf1.input(portName1).value.toInt(), matcher);
+      mod2.output(portName2).put(putVal);
+      expect(mod1.input(portName1).value.toInt(), matcher);
     }
 
     test('in same level', () {
@@ -63,6 +69,10 @@ void main() {
         expect(mid2.outputs.keys.first, contains(portName2));
       });
     });
+
+    test('direct parent leaf connection', () {});
+
+    test('parent through mid to leaf connection', () {});
   });
 
   test(

--- a/test/intf_hier_conn_test.dart
+++ b/test/intf_hier_conn_test.dart
@@ -164,6 +164,15 @@ void main() {
       });
     });
 
+    test('direct parent leaf connection, backwards connection', () async {
+      await testConnection(matchDirection: true, (parent, child) {
+        parent.addSubModule(child);
+        connectInterfaces(
+            child.interface(intfName2), parent.interface(intfName1));
+        return parent;
+      });
+    });
+
     test('parent through mid to leaf connection', () async {
       await testConnection(matchDirection: true, (parent, child) {
         final mid = BridgeModule('mid');

--- a/tool/generate_coverage.sh
+++ b/tool/generate_coverage.sh
@@ -25,6 +25,6 @@ dart pub global run coverage:test_with_coverage --branch-coverage --out=${covera
 
 # requires installing "lcov":
 # > sudo apt install lcov
-genhtml --output-directory=${html_dir} --rc lcov_branch_coverage=1 ${coverage_dir}/lcov.info
+genhtml --output-directory=${html_dir} --rc branch_coverage=1 --ignore-errors category ${coverage_dir}/lcov.info
 
 printf '\n%s\n\n' "Open ${html_dir}/index.html to review code coverage results."


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR fixes bugs related to vertical connections:
- Improves the error message if you have a vertical connection where the interfaces or ports have different directions
- Fixes a bug where vertical connections for directly adjacent modules when connecting interfaces fails with `null` errors

## Related Issue(s)

N/A

## Testing

Adding new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
