### PR TITLE
Fix logger subscription cleanup on reconfiguration

### DIFF
--- a/lib/src/rohd_bridge_logger.dart
+++ b/lib/src/rohd_bridge_logger.dart
@@ -68,6 +68,11 @@ abstract class RohdBridgeLogger {
     bool continueOnError = false,
     bool enableDebugMesage = false,
   }) {
+    // Clean up existing logger subscriptions and file sink
+    Logger.root.clearListeners();
+    fileSink?.close();
+    fileSink = null;
+
     RohdBridgeLogger.continueOnError = continueOnError;
     Logger.root.level = rootLevel;
     _printLevel = printLevel;


### PR DESCRIPTION
## Summary
- Fix resource leak when reconfiguring logger multiple times
- Prevent duplicate log messages from multiple subscriptions
- Clean up existing file sinks before creating new ones

## Changes Made
- Added cleanup logic in `configureLogger()` function
- Clear existing `Logger.root` listeners before adding new ones
- Close existing `fileSink` and reset to null before creating new one
- Prevents accumulation of listeners and file handles

## Test Plan
- Verified the fix addresses the root cause described in the issue
- Code follows existing patterns used in `terminate()` function
- Changes are minimal and focused on the specific problem

Fixes #6