### PR TITLE
Fix, improve, and expand support for `exceptPorts`

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -483,7 +483,7 @@ class BridgeModule extends Module with SystemVerilog {
   /// Throws an [Exception] if no interface with the given [name] exists.
   InterfaceReference interface(String name) =>
       interfaces[name] ??
-      (throw RohdBridgeException('Interface $name not found'));
+      (throw RohdBridgeException('Interface $name not found on $this'));
 
   /// Creates a hierarchical connection by pulling an interface up from a
   /// submodule.

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1289,7 +1289,7 @@ void connectInterfaces(
   String? intf2PathNewName,
   bool allowIntf1PathUniquification = true,
   bool allowIntf2PathUniquification = true,
-  Set<String> exceptPorts = const {},
+  Set<String>? exceptPorts,
   // TODO(mkorbel): finish these,
   //  possibly wont be needed for connectInterfaces
   //  String Function(String logical, String? physical)? portUniquify1,
@@ -1320,7 +1320,7 @@ void connectInterfaces(
     }
     final unusedPortsOnDriver = intf1.getUnmappedInterfacePorts();
     final unusedPortOnReceiver = intf2.getUnmappedInterfacePorts();
-    if (exceptPorts.isNotEmpty) {
+    if (exceptPorts != null && exceptPorts.isNotEmpty) {
       unusedPortsOnDriver.removeWhere(exceptPorts.contains);
       unusedPortOnReceiver.removeWhere(exceptPorts.contains);
     }

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -613,7 +613,7 @@ class BridgeModule extends Module with SystemVerilog {
     }
 
     if (topToConnect != null) {
-      newIntf.connectUpTo(topToConnect);
+      newIntf.connectUpTo(topToConnect, exceptPorts: exceptPorts);
 
       for (final createdInterface in createdInterfaces) {
         for (final portName in interfaceInputPortNames) {

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -223,7 +223,8 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// - [portUniquify]: Function to generate unique port names
   ///
   /// If [exceptPorts] is provided, the resulting interface will exclude those
-  /// ports. Otherwise, the new interface will be of the same type as this one.
+  /// ports (and thus not be of the same type). Otherwise, the new interface
+  /// will be of the same type as this one.
   InterfaceReference punchUpTo(
     BridgeModule newModule, {
     String? newIntfName,
@@ -240,66 +241,17 @@ class InterfaceReference<InterfaceType extends PairInterface>
     _connectAllPortMaps(exceptPorts: exceptPorts);
 
     final newRef = newModule.addInterface(
-      _clonePairInterface(interface, exceptPorts: exceptPorts),
+      interface._cloneExcept(exceptPorts: exceptPorts),
       name: newIntfName ?? name,
       role: role,
       allowNameUniquification: allowNameUniquification,
       portUniquify: portUniquify,
     );
 
-    connectUpTo(newRef);
+    connectUpTo(newRef, exceptPorts: exceptPorts);
 
     return newRef;
   }
-
-  /// Creates a copy of an interface with optional port exclusions.
-  ///
-  /// Returns a new [PairInterface] that contains all the same ports as the
-  /// [original] interface, except for those listed in [exceptPorts]. If
-  /// [exceptPorts] is null or empty, returns a complete clone.
-  ///
-  /// This is used internally when creating interface variants that exclude
-  /// certain ports during hierarchical interface operations.
-  static PairInterface _clonePairInterface(PairInterface original,
-      {Set<String>? exceptPorts}) {
-    if (exceptPorts == null || exceptPorts.isEmpty) {
-      return original.clone();
-    }
-
-    return PairInterface(
-      portsFromConsumer: _getMatchPorts(original, PairDirection.fromConsumer,
-              exceptPorts: exceptPorts)
-          .toList(),
-      portsFromProvider: _getMatchPorts(original, PairDirection.fromProvider,
-              exceptPorts: exceptPorts)
-          .toList(),
-      sharedInputPorts: _getMatchPorts(original, PairDirection.sharedInputs,
-              exceptPorts: exceptPorts)
-          .toList(),
-      commonInOutPorts: _getMatchPorts(original, PairDirection.commonInOuts,
-              exceptPorts: exceptPorts)
-          .toList(),
-      modify: original.modify,
-    );
-  }
-
-  /// Extracts ports with a specific direction tag from an interface.
-  ///
-  /// Returns a list of [Logic] ports from the [interface] that are tagged with
-  /// the specified [tag] direction, excluding any ports listed in
-  /// [exceptPorts]. Creates appropriate port instances ([Logic], [LogicArray],
-  /// or [LogicNet]) based on the original port types.
-  ///
-  /// This is a utility method for interface cloning operations.
-  static List<Logic> _getMatchPorts(
-          Interface<PairDirection> interface, PairDirection tag,
-          {Set<String>? exceptPorts}) =>
-      interface
-          .getPorts({tag})
-          .entries
-          .where((e) => exceptPorts == null || !exceptPorts.contains(e.key))
-          .map((e) => e.value.clone(name: e.key))
-          .toList(growable: false);
 
   /// Establishes a hierarchical "upward" connection to a parent interface.
   ///
@@ -312,7 +264,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// - Shared and common ports follow interface-specific rules
   ///
   /// The [other] must be on this reference's [module]'s parent.
-  void connectUpTo(InterfaceReference other) {
+  void connectUpTo(InterfaceReference other, {Set<String>? exceptPorts}) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (module.parent != other.module) {
       throw RohdBridgeException(
@@ -324,30 +276,42 @@ class InterfaceReference<InterfaceType extends PairInterface>
       other._introduceInternalInterface();
     }
 
-    _connectAllPortMaps(exceptPorts: null);
-    other._connectAllPortMaps(exceptPorts: null);
+    _connectAllPortMaps(exceptPorts: exceptPorts);
+    other._connectAllPortMaps(exceptPorts: exceptPorts);
 
     switch (role) {
       case (PairRole.provider):
         other.internalInterface!
-          ..receiveOther(interface, const [
-            PairDirection.fromProvider,
-          ])
-          ..driveOther(interface, const [
-            PairDirection.fromConsumer,
-            PairDirection.sharedInputs,
-            PairDirection.commonInOuts,
-          ]);
+          .._receiveOtherExcept(
+              interface,
+              const [
+                PairDirection.fromProvider,
+              ],
+              exceptPorts: exceptPorts)
+          .._driveOtherExcept(
+              interface,
+              const [
+                PairDirection.fromConsumer,
+                PairDirection.sharedInputs,
+                PairDirection.commonInOuts,
+              ],
+              exceptPorts: exceptPorts);
       case (PairRole.consumer):
         other.internalInterface!
-          ..receiveOther(interface, const [
-            PairDirection.fromConsumer,
-          ])
-          ..driveOther(interface, const [
-            PairDirection.fromProvider,
-            PairDirection.sharedInputs,
-            PairDirection.commonInOuts,
-          ]);
+          .._receiveOtherExcept(
+              interface,
+              const [
+                PairDirection.fromConsumer,
+              ],
+              exceptPorts: exceptPorts)
+          .._driveOtherExcept(
+              interface,
+              const [
+                PairDirection.fromProvider,
+                PairDirection.sharedInputs,
+                PairDirection.commonInOuts,
+              ],
+              exceptPorts: exceptPorts);
     }
   }
 
@@ -362,8 +326,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// rather than using bulk interface connection methods.
   ///
   /// Throws an exception if both interfaces have the same role.
-  void connectTo(InterfaceReference other,
-      {Set<String> exceptPorts = const {}}) {
+  void connectTo(InterfaceReference other, {Set<String>? exceptPorts}) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (other.module.parent != module.parent) {
       throw RohdBridgeException('Both interfaces must be on modules that share'
@@ -380,33 +343,20 @@ class InterfaceReference<InterfaceType extends PairInterface>
     final provider = role == PairRole.provider ? this : other;
     final consumer = role == PairRole.consumer ? this : other;
 
-    if (exceptPorts.isNotEmpty) {
-      provider.interface.getPorts([
-        PairDirection.fromProvider,
-        PairDirection.commonInOuts,
-      ]).forEach((portName, thisPort) {
-        if (!exceptPorts.contains(portName)) {
-          consumer.interface.port(portName) <= thisPort;
-        }
-      });
+    provider.interface._driveOtherExcept(
+        consumer.interface,
+        [
+          PairDirection.fromProvider,
+          PairDirection.commonInOuts,
+        ],
+        exceptPorts: exceptPorts);
 
-      consumer.interface.getPorts([
-        PairDirection.fromConsumer,
-      ]).forEach((portName, thisPort) {
-        if (!exceptPorts.contains(portName)) {
-          provider.interface.port(portName) <= thisPort;
-        }
-      });
-    } else {
-      provider.interface.driveOther(consumer.interface, [
-        PairDirection.fromProvider,
-        PairDirection.commonInOuts,
-      ]);
-
-      consumer.interface.driveOther(provider.interface, [
-        PairDirection.fromConsumer,
-      ]);
-    }
+    consumer.interface._driveOtherExcept(
+        provider.interface,
+        [
+          PairDirection.fromConsumer,
+        ],
+        exceptPorts: exceptPorts);
   }
 
   /// Creates a copy of this interface in a submodule.
@@ -424,23 +374,25 @@ class InterfaceReference<InterfaceType extends PairInterface>
   ///
   /// The [subModule] must be a child of this interface's [module].
   InterfaceReference punchDownTo(BridgeModule subModule,
-      {String? newIntfName, bool allowNameUniquification = false}) {
+      {String? newIntfName,
+      bool allowNameUniquification = false,
+      Set<String>? exceptPorts}) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (subModule.parent != module) {
       throw RohdBridgeException(
           'The subModule must be a direct child of this module.');
     }
 
-    _connectAllPortMaps(exceptPorts: null);
+    _connectAllPortMaps(exceptPorts: exceptPorts);
 
     final newRef = subModule.addInterface(
-      interface,
+      interface._cloneExcept(exceptPorts: exceptPorts),
       name: newIntfName ?? name,
       role: role,
       allowNameUniquification: allowNameUniquification,
     );
 
-    connectDownTo(newRef);
+    connectDownTo(newRef, exceptPorts: exceptPorts);
 
     return newRef;
   }
@@ -452,7 +404,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// the interface role, with signals flowing from parent to child.
   ///
   /// The [other] must be on a sub-module of this [module].
-  void connectDownTo(InterfaceReference other) {
+  void connectDownTo(InterfaceReference other, {Set<String>? exceptPorts}) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (other.module.parent != module) {
       throw RohdBridgeException(
@@ -464,30 +416,42 @@ class InterfaceReference<InterfaceType extends PairInterface>
       _introduceInternalInterface();
     }
 
-    _connectAllPortMaps(exceptPorts: null);
-    other._connectAllPortMaps(exceptPorts: null);
+    _connectAllPortMaps(exceptPorts: exceptPorts);
+    other._connectAllPortMaps(exceptPorts: exceptPorts);
 
     switch (role) {
       case (PairRole.provider):
         internalInterface!
-          ..driveOther(other.interface, const [
-            PairDirection.fromConsumer,
-            PairDirection.sharedInputs,
-            PairDirection.commonInOuts,
-          ])
-          ..receiveOther(other.interface, const [
-            PairDirection.fromProvider,
-          ]);
+          .._driveOtherExcept(
+              other.interface,
+              const [
+                PairDirection.fromConsumer,
+                PairDirection.sharedInputs,
+                PairDirection.commonInOuts,
+              ],
+              exceptPorts: exceptPorts)
+          .._receiveOtherExcept(
+              other.interface,
+              const [
+                PairDirection.fromProvider,
+              ],
+              exceptPorts: exceptPorts);
       case (PairRole.consumer):
         internalInterface!
-          ..driveOther(other.interface, const [
-            PairDirection.fromProvider,
-            PairDirection.sharedInputs,
-            PairDirection.commonInOuts,
-          ])
-          ..receiveOther(other.interface, const [
-            PairDirection.fromConsumer,
-          ]);
+          .._driveOtherExcept(
+              other.interface,
+              const [
+                PairDirection.fromProvider,
+                PairDirection.sharedInputs,
+                PairDirection.commonInOuts,
+              ],
+              exceptPorts: exceptPorts)
+          .._receiveOtherExcept(
+              other.interface,
+              const [
+                PairDirection.fromConsumer,
+              ],
+              exceptPorts: exceptPorts);
     }
   }
 
@@ -535,4 +499,74 @@ class InterfaceReference<InterfaceType extends PairInterface>
 
     return unmappedPorts;
   }
+}
+
+extension _ExceptPairInterfaceExtensions on PairInterface {
+  /// Performs the same operation as [driveOther], but excludes ports listed in
+  /// [exceptPorts].
+  void _driveOtherExcept(PairInterface other, Iterable<PairDirection> tags,
+      {required Set<String>? exceptPorts}) {
+    getPorts(tags).forEach((portName, thisPort) {
+      if (exceptPorts != null && !exceptPorts.contains(portName)) {
+        other.port(portName) <= thisPort;
+      }
+    });
+  }
+
+  /// Performs the same operation as [receiveOther], but excludes ports listed
+  /// in [exceptPorts].
+  void _receiveOtherExcept(PairInterface other, Iterable<PairDirection> tags,
+      {required Set<String>? exceptPorts}) {
+    getPorts(tags).forEach((portName, thisPort) {
+      if (exceptPorts != null && !exceptPorts.contains(portName)) {
+        thisPort <= other.port(portName);
+      }
+    });
+  }
+
+  /// Creates a copy of an interface with optional port exclusions.
+  ///
+  /// Returns a new [PairInterface] that contains all the same ports as the
+  /// `this` interface, except for those listed in [exceptPorts]. If
+  /// [exceptPorts] is null or empty, returns a complete clone.
+  ///
+  /// This is used internally when creating interface variants that exclude
+  /// certain ports during hierarchical interface operations.
+  PairInterface _cloneExcept({required Set<String>? exceptPorts}) {
+    if (exceptPorts == null || exceptPorts.isEmpty) {
+      return clone();
+    }
+
+    return PairInterface(
+      portsFromConsumer: _getMatchPortsExcept(PairDirection.fromConsumer,
+              exceptPorts: exceptPorts)
+          .toList(),
+      portsFromProvider: _getMatchPortsExcept(PairDirection.fromProvider,
+              exceptPorts: exceptPorts)
+          .toList(),
+      sharedInputPorts: _getMatchPortsExcept(PairDirection.sharedInputs,
+              exceptPorts: exceptPorts)
+          .toList(),
+      commonInOutPorts: _getMatchPortsExcept(PairDirection.commonInOuts,
+              exceptPorts: exceptPorts)
+          .toList(),
+      modify: modify,
+    );
+  }
+
+  /// Extracts ports with a specific direction tag from an interface.
+  ///
+  /// Returns a list of [Logic] ports from `this` that are tagged with
+  /// the specified [tag] direction, excluding any ports listed in
+  /// [exceptPorts]. Creates appropriate port instances ([Logic], [LogicArray],
+  /// or [LogicNet]) based on the original port types.
+  ///
+  /// This is a utility method for interface cloning operations.
+  List<Logic> _getMatchPortsExcept(PairDirection tag,
+          {required Set<String>? exceptPorts}) =>
+      getPorts({tag})
+          .entries
+          .where((e) => exceptPorts == null || !exceptPorts.contains(e.key))
+          .map((e) => e.value.clone(name: e.key))
+          .toList(growable: false);
 }

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -113,6 +113,8 @@ class InterfaceReference<InterfaceType extends PairInterface>
     }
   }
 
+  //TODO: also test portuniquify?
+
   /// Creates an [internalInterface] on this [InterfaceReference], connecting
   /// ports to existing [portMaps] when they exist, and creating new ports
   /// otherwise.
@@ -373,10 +375,13 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// hierarchy.
   ///
   /// The [subModule] must be a child of this interface's [module].
-  InterfaceReference punchDownTo(BridgeModule subModule,
-      {String? newIntfName,
-      bool allowNameUniquification = false,
-      Set<String>? exceptPorts}) {
+  InterfaceReference punchDownTo(
+    BridgeModule subModule, {
+    String? newIntfName,
+    bool allowNameUniquification = false,
+    Set<String>? exceptPorts,
+    String Function(String logical)? portUniquify,
+  }) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (subModule.parent != module) {
       throw RohdBridgeException(
@@ -390,6 +395,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
       name: newIntfName ?? name,
       role: role,
       allowNameUniquification: allowNameUniquification,
+      portUniquify: portUniquify,
     );
 
     connectDownTo(newRef, exceptPorts: exceptPorts);
@@ -567,6 +573,6 @@ extension _ExceptPairInterfaceExtensions on PairInterface {
       getPorts({tag})
           .entries
           .where((e) => exceptPorts == null || !exceptPorts.contains(e.key))
-          .map((e) => e.value.clone(name: e.key))
+          .map((e) => e.value.clone())
           .toList(growable: false);
 }

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -113,8 +113,6 @@ class InterfaceReference<InterfaceType extends PairInterface>
     }
   }
 
-  //TODO: also test portuniquify?
-
   /// Creates an [internalInterface] on this [InterfaceReference], connecting
   /// ports to existing [portMaps] when they exist, and creating new ports
   /// otherwise.

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -505,6 +505,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
   }
 }
 
+/// Extensions on [PairInterface] to handle `exceptPorts` functionality.
 extension _ExceptPairInterfaceExtensions on PairInterface {
   /// Performs the same operation as [driveOther], but excludes ports listed in
   /// [exceptPorts].

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -511,7 +511,7 @@ extension _ExceptPairInterfaceExtensions on PairInterface {
   void _driveOtherExcept(PairInterface other, Iterable<PairDirection> tags,
       {required Set<String>? exceptPorts}) {
     getPorts(tags).forEach((portName, thisPort) {
-      if (exceptPorts != null && !exceptPorts.contains(portName)) {
+      if (exceptPorts == null || !exceptPorts.contains(portName)) {
         other.port(portName) <= thisPort;
       }
     });
@@ -522,7 +522,7 @@ extension _ExceptPairInterfaceExtensions on PairInterface {
   void _receiveOtherExcept(PairInterface other, Iterable<PairDirection> tags,
       {required Set<String>? exceptPorts}) {
     getPorts(tags).forEach((portName, thisPort) {
-      if (exceptPorts != null && !exceptPorts.contains(portName)) {
+      if (exceptPorts == null || !exceptPorts.contains(portName)) {
         thisPort <= other.port(portName);
       }
     });

--- a/test/bridge_interface_test.dart
+++ b/test/bridge_interface_test.dart
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// std_interfaces_test.dart
+// bridge_interface_test.dart
 // Unit tests for standard interface JSON parsing.
 //
 // 2024
@@ -15,7 +15,7 @@ import 'package:rohd_bridge/src/bridge_interface.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  test('Custom Interaface ofJson', () async {
+  test('Bridge Interface simple', () async {
     final portsFromConsumer = {'a': 1, 'b': 2, 'c': 3};
     final portsFromProvider = {'d': 4, 'e': 5, 'f': 6};
     final intf = BridgeInterface(

--- a/test/interfaces_exclude_test.dart
+++ b/test/interfaces_exclude_test.dart
@@ -150,13 +150,7 @@ void main() {
   });
 
   // TODO Test plan:
-  // - connectInterfaces
-  //   -> passes correctly to pullUpInterface, _pullUpInterfaceAndConnect
   // - InterfaceReference
-  //   - punchUpTo
-  //     -> _connectAllPortMaps, cloneExcept, connectUpTo
-  //   - punchDownTo
-  //     -> _connectAllPortMaps, cloneExcept, connectDownTo
   //   - connectUpTo
   //     -> _connectAllPortMaps (both), receive and drive other (both)
   //   - connectDownTo
@@ -191,7 +185,7 @@ void main() {
   });
 
   test('connectInterfaces with exceptPorts', () async {
-    // - BridgeModule.connectInterfaces
+    // - connectInterfaces
     //   -> passes correctly to InterfaceReference.connectUpTo, connectDownTo
 
     final top = BridgeModule('top');
@@ -220,6 +214,50 @@ void main() {
     expect(mid1.hasPortWithSubstring('orange'), isTrue);
     expect(mid2.hasPortWithSubstring('apple'), isTrue);
     expect(mid2.hasPortWithSubstring('orange'), isTrue);
+  });
+
+  test('punchUpTo with exceptPorts', () async {
+    //   - InterfaceReference.punchUpTo
+    //     -> _connectAllPortMaps, cloneExcept, connectUpTo
+
+    final top = BridgeModule('top');
+    final leaf = LM1();
+    top.addSubModule(leaf);
+
+    leaf.interface('intf1').punchUpTo(top, exceptPorts: {'fp', 'fc'});
+
+    await top.build();
+
+    expect(top.hasPortWithSubstring('fp'), isFalse);
+    expect(top.hasPortWithSubstring('fc'), isFalse);
+
+    expect(top.hasPortWithSubstring('orange'), isTrue);
+    expect(top.hasPortWithSubstring('apple'), isTrue);
+
+    expect(top.interface('intf1').interface,
+        isNot(equals(leaf.interface('intf1').interface)));
+  });
+
+  test('punchDownTo with exceptPorts', () async {
+    //   - InterfaceReference.punchDownTo
+    //     -> _connectAllPortMaps, cloneExcept, connectDownTo
+
+    final top = LM1();
+    final leaf = BridgeModule('leaf');
+    top.addSubModule(leaf);
+
+    top.interface('intf1').punchDownTo(leaf, exceptPorts: {'fp', 'fc'});
+
+    await top.build();
+
+    expect(leaf.hasPortWithSubstring('fp'), isFalse);
+    expect(leaf.hasPortWithSubstring('fc'), isFalse);
+
+    expect(leaf.hasPortWithSubstring('orange'), isTrue);
+    expect(leaf.hasPortWithSubstring('apple'), isTrue);
+
+    expect(top.interface('intf1').interface,
+        isNot(equals(leaf.interface('intf1').interface)));
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fix bugs and missing APIs where `exceptPorts` was missing or not respected in various APIs.

Also, fixed a bug where we were missing a `portUniquify` argument on `punchDownTo`.

## Related Issue(s)

Fix #10

## Testing

Added new tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
