### PR TITLE
Change back `getHierarchyDownTo` to follow expectations

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1121,11 +1121,15 @@ void connectPorts(
 
   BridgeModule? commonParent;
 
+  final driverIsReceiver = driver.module == receiver.module;
+
   final driverContainsReceiver =
-      driver.module.getHierarchyDownTo(receiver.module) != null;
+      (driver.module.getHierarchyDownTo(receiver.module) != null) &&
+          !driverIsReceiver;
 
   final receiverContainsDriver =
-      receiver.module.getHierarchyDownTo(driver.module) != null;
+      (receiver.module.getHierarchyDownTo(driver.module) != null) &&
+          !driverIsReceiver;
 
   if (!driverContainsReceiver &&
       !receiverContainsDriver &&

--- a/lib/src/module_extensions.dart
+++ b/lib/src/module_extensions.dart
@@ -101,10 +101,10 @@ extension RohdBridgeModuleExtensions on Module {
   /// [instance].
   ///
   /// If there is no path found, returns `null`. If [instance] is the same as
-  /// `this`, returns `null`.
+  /// `this`, returns a list with just the one module in it.
   List<Module>? getHierarchyDownTo(Module instance) {
     if (instance == this) {
-      return null;
+      return [this];
     }
 
     Module? parent = instance;

--- a/test/hierarchy_connection_test.dart
+++ b/test/hierarchy_connection_test.dart
@@ -254,8 +254,11 @@ void main() {
     expect(mod2.port('apple').port.value, LogicValue.of('z1zz'));
   });
 
-  test('hierarchy down to is null for same module', () {
+  test('hierarchy down to is itself for same module', () {
     final mod1 = BridgeModule('mod1');
-    expect(mod1.getHierarchyDownTo(mod1), isNull);
+    final hier = mod1.getHierarchyDownTo(mod1);
+    expect(hier, isNotNull);
+    expect(hier!.length, 1);
+    expect(hier, contains(mod1));
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

https://github.com/intel/rohd-bridge/pull/11 mistakenly thought it was a bug that calling `getHierarchyDownTo` on itself should return `null`, but that was a bad change to make, since usually it returns itself and the destination.  Made some other changes in other functions to support the proper behavior instead of making the API inconsistent.

## Related Issue(s)

N/A

## Testing

Modified tests + existing tests cover it.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
