### PR TITLE
Allow loop-back from output to input on same module

### DIFF
--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -135,9 +135,10 @@ sealed class PortReference extends Reference {
     }
 
     if (relativeLocation == _RelativePortLocation.sameModule &&
-        direction == PortDirection.input) {
+        direction == PortDirection.input &&
+        other.direction == PortDirection.input) {
       throw RohdBridgeException(
-          'An port $other on module ${other.module} cannot drive an'
+          'An input port $other on module ${other.module} cannot drive an'
           ' input $this on the same module');
     }
 
@@ -275,7 +276,13 @@ sealed class PortReference extends Reference {
           }
         }
 
-        return (driver: other._internalPort, receiver: _internalPort);
+        if (direction == PortDirection.input &&
+            other.direction == PortDirection.output) {
+          // loop-back
+          return (driver: other._externalPort, receiver: _externalPort);
+        } else {
+          return (driver: other._internalPort, receiver: _internalPort);
+        }
 
       case _RelativePortLocation.sameLevel:
         return (driver: other._externalPort, receiver: _externalPort);
@@ -322,7 +329,13 @@ sealed class PortReference extends Reference {
           }
         }
 
-        return other._internalPortSubset;
+        if (direction == PortDirection.input &&
+            other.direction == PortDirection.output) {
+          // loop-back
+          return other._externalPortSubset;
+        } else {
+          return other._internalPortSubset;
+        }
 
       case _RelativePortLocation.sameLevel:
         return other._externalPortSubset;

--- a/test/intf_port_module_port_connections_test.dart
+++ b/test/intf_port_module_port_connections_test.dart
@@ -192,7 +192,8 @@ void main() {
 
                     if (testCase.relativePosition ==
                             _RelativePosition.sameModule &&
-                        testCase.dst.direction == PortDirection.input) {
+                        testCase.dst.direction == PortDirection.input &&
+                        testCase.src.direction == PortDirection.input) {
                       // port cant drive input on same module
                       expectFailure = true;
                     }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a restriction that prevented driving an input of a module from another port of that same module.  However, it makes sense to be able to do a loop-back connection.  This PR fixes that case and makes it legal.

## Related Issue(s)

N/A

## Testing

Updated tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
