### PR TITLE
Improve tie-off tests to check SV and with hierarchy

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   collection: ^1.15.0
   logging: ^1.2.0
   meta: ^1.15.0
-  rohd: ^0.6.7
+  rohd: ^0.6.8
 
 dev_dependencies:
   test: ^1.16.0


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The bug from https://github.com/intel/rohd/pull/643 was hit by tests in ROHD Bridge, but checks were not present to ensure the generated SV looked right and had the necessary constant assignments.  This PR tightens up the tests to make sure we don't hit that bug again (even though more tests were added in ROHD as well).

## Related Issue(s)

N/A

## Testing

Just improving tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
