### PR TITLE
Support same module connection type specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.X.X
+
+- Added `SameModuleConnectionType` enum to disambiguate same-module connections involving `inOut` ports. When connecting two ports on the same module where at least one is `inOut` and neither is `input`, a `SameModuleConnectionType` (`loopback` or `passthrough`) must now be provided to `gets()` or `connectPorts()` to specify whether the connection should use external-facing or internal-facing ports. (<https://github.com/intel/rohd-bridge/pull/XX>).
+
 ## 0.2.2
 
 - Fixed handling of connections between `PairInterface`s that contained `subInterfaces`, and added checks that `exceptPorts` are not used in those cases (<https://github.com/intel/rohd-bridge/pull/37>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## X.X.X
+## Next release
 
-- Added `SameModuleConnectionType` enum to disambiguate same-module connections involving `inOut` ports. When connecting two ports on the same module where at least one is `inOut` and neither is `input`, a `SameModuleConnectionType` (`loopback` or `passthrough`) must now be provided to `gets()` or `connectPorts()` to specify whether the connection should use external-facing or internal-facing ports. (<https://github.com/intel/rohd-bridge/pull/XX>).
+- Added `SameModuleConnectionType` enum to disambiguate same-module connections involving `inOut` ports. When connecting two ports on the same module where at least one is `inOut` and neither is `input`, a `SameModuleConnectionType` (`loopback` or `passthrough`) must now be provided to `gets()` or `connectPorts()` to specify whether the connection should use external-facing or internal-facing ports. (<https://github.com/intel/rohd-bridge/pull/39>).
 
 ## 0.2.2
 

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1109,6 +1109,13 @@ class BridgeModule extends Module with SystemVerilog {
 /// `false`, then the port names will not be uniquified on those paths.
 /// Uniquification also respects [BridgeModule.allowUniquification] at each
 /// level.
+///
+/// When [driver] and [receiver] are on the same module and the connection is
+/// ambiguous (at least one port is [PortDirection.inOut] and neither is
+/// [PortDirection.input]), [sameModuleConnectionType] must be provided to
+/// disambiguate whether the connection is a [SameModuleConnectionType.loopback]
+/// (using external-facing ports) or a [SameModuleConnectionType.passthrough]
+/// (using internal-facing ports). See [PortReference.gets] for full details.
 void connectPorts(
   PortReference driver,
   PortReference receiver, {
@@ -1116,6 +1123,7 @@ void connectPorts(
   String? receiverPathNewPortName,
   bool allowDriverPathUniquification = true,
   bool allowReceiverPathUniquification = true,
+  SameModuleConnectionType? sameModuleConnectionType,
 }) {
   // TODO(mkorbel1): need to add better control over naming of intermediate
   //  ports -- default allow renaming? or should it prefer the top/leaf?
@@ -1280,7 +1288,8 @@ void connectPorts(
     receiverPortModule._upperSourceMap[driverPortRef] = createdReceiverPort;
   }
 
-  receiverPortRef.gets(driverPortRef);
+  receiverPortRef.gets(driverPortRef,
+      sameModuleConnectionType: sameModuleConnectionType);
 }
 
 /// Connects [intf1] to [intf2], creating all necessary ports through the

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -190,6 +190,14 @@ sealed class PortReference extends Reference {
           'parent module ($module) input ($this).');
     }
 
+    if (relativeLocation != _RelativePortLocation.sameModule &&
+        sameModuleConnectionType != null) {
+      throw RohdBridgeException(
+          'SameModuleConnectionType should only be provided when connecting'
+          ' ports on the same module, but $this is on $module'
+          ' and $other is on ${other.module}.');
+    }
+
     // Same-module connection type validation
     var resolvedConnectionType = sameModuleConnectionType;
     if (relativeLocation == _RelativePortLocation.sameModule &&

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -12,6 +12,31 @@
 
 part of 'references.dart';
 
+/// The type of connection to make between two ports on the same module.
+///
+/// When connecting two ports on the same [BridgeModule], the connection can
+/// either be a [loopback] (external, pin-to-pin) or a [passthrough] (internal,
+/// net-to-net).
+///
+/// For most direction combinations, the connection type is unambiguous and
+/// [PortReference.gets] can infer it automatically. However, when at least one
+/// port is [PortDirection.inOut] and neither port is [PortDirection.input], the
+/// connection type must be explicitly specified via [PortReference.gets] or
+/// `connectPorts`.
+enum SameModuleConnectionType {
+  /// An external (loopback) connection between ports on the same module.
+  ///
+  /// This connects the external-facing sides of the ports, making the
+  /// connection visible outside the module.
+  loopback,
+
+  /// An internal (passthrough) connection between ports on the same module.
+  ///
+  /// This connects the internal-facing sides of the ports, making the
+  /// connection visible only within the module.
+  passthrough,
+}
+
 /// An enumeration of the possible relative locations of two ports' modules.
 enum _RelativePortLocation {
   thisAboveOther,
@@ -93,7 +118,13 @@ sealed class PortReference extends Reference {
   /// This establishes a connection where the signal from [other] drives this
   /// port. The connection respects the hierarchical nature of the modules and
   /// handles directionality of ports appropriately.
-  void gets(PortReference other) {
+  ///
+  /// When connecting two ports on the same module where the connection type is
+  /// ambiguous (at least one port is [PortDirection.inOut] and neither is
+  /// [PortDirection.input]), a [sameModuleConnectionType] must be provided to
+  /// disambiguate.
+  void gets(PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType}) {
     final relativeLocation = _relativeLocationOf(other);
 
     if (relativeLocation == _RelativePortLocation.sameModule &&
@@ -159,12 +190,92 @@ sealed class PortReference extends Reference {
           'parent module ($module) input ($this).');
     }
 
-    getsInternal(other);
+    // Same-module connection type validation
+    var resolvedConnectionType = sameModuleConnectionType;
+    if (relativeLocation == _RelativePortLocation.sameModule &&
+        other is! InterfacePortReference &&
+        this is! InterfacePortReference) {
+      resolvedConnectionType =
+          _validateSameModuleConnectionType(other, sameModuleConnectionType);
+    }
+
+    getsInternal(other, sameModuleConnectionType: resolvedConnectionType);
+  }
+
+  /// Validates and resolves the [SameModuleConnectionType] for a same-module
+  /// connection.
+  ///
+  /// Returns the resolved [SameModuleConnectionType] to use for the connection,
+  /// or `null` if it doesn't matter.
+  ///
+  /// Throws if the connection is ambiguous and no type is specified, or if the
+  /// specified type conflicts with the forced connection type for the given
+  /// direction combination.
+  SameModuleConnectionType? _validateSameModuleConnectionType(
+      PortReference other, SameModuleConnectionType? provided) {
+    // Determine if the connection is ambiguous:
+    // At least one port is inOut and neither is input.
+    final isAmbiguous = (direction == PortDirection.inOut ||
+            other.direction == PortDirection.inOut) &&
+        direction != PortDirection.input &&
+        other.direction != PortDirection.input;
+
+    if (isAmbiguous) {
+      if (provided == null) {
+        throw RohdBridgeException('Connecting ${other.direction.name} $other to'
+            ' ${direction.name} $this on the same module (${module.name})'
+            ' is ambiguous.'
+            ' Provide a SameModuleConnectionType'
+            ' (loopback or passthrough) to disambiguate.');
+      }
+
+      // output←inOut with loopback is invalid: output ports cannot be driven
+      // by external inOut sources.
+      if (direction == PortDirection.output &&
+          other.direction == PortDirection.inOut &&
+          provided == SameModuleConnectionType.loopback) {
+        throw RohdBridgeException(
+            'SameModuleConnectionType.loopback is not valid for'
+            ' output←inOut on the same module.'
+            ' An output port cannot be driven by the external side of an'
+            ' inOut port. Use passthrough instead.');
+      }
+
+      return provided;
+    }
+
+    // Non-ambiguous cases: determine the forced type.
+    SameModuleConnectionType? forcedType;
+
+    if (direction == PortDirection.input) {
+      // input receiver → always loopback (external)
+      forcedType = SameModuleConnectionType.loopback;
+    } else if (direction == PortDirection.output &&
+        other.direction == PortDirection.input) {
+      // output←input → always passthrough (internal)
+      forcedType = SameModuleConnectionType.passthrough;
+    } else if (direction == PortDirection.inOut &&
+        other.direction == PortDirection.input) {
+      // inOut←input → always passthrough (internal)
+      forcedType = SameModuleConnectionType.passthrough;
+    }
+    // output←output → equivalent, no forced type
+
+    // If a type was provided, validate it matches the forced type.
+    if (provided != null && forcedType != null && provided != forcedType) {
+      throw RohdBridgeException(
+          'SameModuleConnectionType.${provided.name} is not valid for'
+          ' ${direction.name}←${other.direction.name} on the same module.'
+          ' Must be ${forcedType.name}.');
+    }
+
+    return provided ?? forcedType;
   }
 
   /// Implementation of [gets] after some validation.
   @internal
-  void getsInternal(PortReference other);
+  void getsInternal(PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType});
 
   /// Connects this port to be driven by a [Logic] [other].
   ///
@@ -247,8 +358,12 @@ sealed class PortReference extends Reference {
   /// The receiver and driver considering the relative hierarchy of the ports.
   ///
   /// It is assumed that [other] is driving `this` (part of a call to [gets]).
+  ///
+  /// When [sameModuleConnectionType] is provided for same-module connections,
+  /// it overrides the default internal/external port selection.
   ({Logic receiver, Logic driver}) _relativeReceiverAndDriver(
-      PortReference other) {
+      PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType}) {
     final loc = _relativeLocationOf(other);
 
     switch (loc) {
@@ -279,6 +394,14 @@ sealed class PortReference extends Reference {
                 return (receiver: _externalPort, driver: other._externalPort);
               }
           }
+        }
+
+        // When an explicit connection type is provided, use it directly.
+        if (sameModuleConnectionType == SameModuleConnectionType.loopback) {
+          return (driver: other._externalPort, receiver: _externalPort);
+        } else if (sameModuleConnectionType ==
+            SameModuleConnectionType.passthrough) {
+          return (driver: other._internalPort, receiver: _internalPort);
         }
 
         if (direction == PortDirection.input &&
@@ -301,7 +424,11 @@ sealed class PortReference extends Reference {
   /// The driver subset considering the relative hierarchy of the ports.
   ///
   /// It is assumed that [other] is driving `this` (part of a call to [gets]).
-  dynamic _relativeDriverSubset(PortReference other) {
+  ///
+  /// When [sameModuleConnectionType] is provided for same-module connections,
+  /// it overrides the default internal/external port selection.
+  dynamic _relativeDriverSubset(PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType}) {
     final loc = _relativeLocationOf(other);
 
     switch (loc) {
@@ -332,6 +459,14 @@ sealed class PortReference extends Reference {
                 return other._externalPortSubset;
               }
           }
+        }
+
+        // When an explicit connection type is provided, use it directly.
+        if (sameModuleConnectionType == SameModuleConnectionType.loopback) {
+          return other._externalPortSubset;
+        } else if (sameModuleConnectionType ==
+            SameModuleConnectionType.passthrough) {
+          return other._internalPortSubset;
         }
 
         if (direction == PortDirection.input &&

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // slice_port_reference.dart
@@ -257,9 +257,13 @@ class SlicePortReference extends PortReference {
 
   @override
   @internal
-  void getsInternal(PortReference other) {
-    var receiverPort = _relativeReceiverAndDriver(other).receiver;
-    final otherDriver = _relativeDriverSubset(other);
+  void getsInternal(PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType}) {
+    var receiverPort = _relativeReceiverAndDriver(other,
+            sameModuleConnectionType: sameModuleConnectionType)
+        .receiver;
+    final otherDriver = _relativeDriverSubset(other,
+        sameModuleConnectionType: sameModuleConnectionType);
 
     int? leafIndex;
 

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // standard_port_reference.dart
@@ -44,14 +44,19 @@ class StandardPortReference extends PortReference {
 
   @override
   @internal
-  void getsInternal(PortReference other) {
+  void getsInternal(PortReference other,
+      {SameModuleConnectionType? sameModuleConnectionType}) {
     if (other is StandardPortReference) {
-      final (receiver: receiver, driver: driver) =
-          _relativeReceiverAndDriver(other);
+      final (receiver: receiver, driver: driver) = _relativeReceiverAndDriver(
+          other,
+          sameModuleConnectionType: sameModuleConnectionType);
       receiver <= driver;
     } else if (other is SlicePortReference) {
-      final otherDriver = _relativeDriverSubset(other);
-      final receiver = _relativeReceiverAndDriver(other).receiver;
+      final otherDriver = _relativeDriverSubset(other,
+          sameModuleConnectionType: sameModuleConnectionType);
+      final receiver = _relativeReceiverAndDriver(other,
+              sameModuleConnectionType: sameModuleConnectionType)
+          .receiver;
 
       if (otherDriver is Logic) {
         receiver <= otherDriver;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   collection: ^1.15.0
   logging: ^1.2.0
   meta: ^1.15.0
-  rohd: ^0.6.7
+  rohd: ^0.6.9
 
 dev_dependencies:
   test: ^1.16.0

--- a/test/connection_extractor_test.dart
+++ b/test/connection_extractor_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // connection_extractor_test.dart
@@ -1056,7 +1056,8 @@ void main() {
 
       final top = BridgeModule('top')..addSubModule(mod);
 
-      connectPorts(port.slice(2, 1), port.slice(5, 4));
+      connectPorts(port.slice(2, 1), port.slice(5, 4),
+          sameModuleConnectionType: SameModuleConnectionType.passthrough);
 
       top.pullUpPort(mod.createPort('clk', PortDirection.input));
 

--- a/test/intf_port_module_port_connections_test.dart
+++ b/test/intf_port_module_port_connections_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // intf_port_module_port_connections_test.dart
@@ -195,6 +195,19 @@ void main() {
                         testCase.dst.direction == PortDirection.input &&
                         testCase.src.direction == PortDirection.input) {
                       // port cant drive input on same module
+                      expectFailure = true;
+                    }
+
+                    if (testCase.relativePosition ==
+                            _RelativePosition.sameModule &&
+                        !testCase.src.isIntfPort &&
+                        !testCase.dst.isIntfPort &&
+                        (testCase.src.direction == PortDirection.inOut ||
+                            testCase.dst.direction == PortDirection.inOut) &&
+                        testCase.src.direction != PortDirection.input &&
+                        testCase.dst.direction != PortDirection.input) {
+                      // ambiguous same-module connection involving inOut
+                      // requires SameModuleConnectionType
                       expectFailure = true;
                     }
 

--- a/test/same_module_connection_test.dart
+++ b/test/same_module_connection_test.dart
@@ -327,14 +327,16 @@ void main() {
       }
     });
 
-    group('non-same-module ignores enum', () {
+    group('non-same-module rejects enum', () {
       for (final ct in [
         SameModuleConnectionType.loopback,
         SameModuleConnectionType.passthrough,
       ]) {
-        test('sibling modules with ${ct.name}', () async {
+        test('sibling modules with ${ct.name}', () {
           final modA = BridgeModule('modA');
           final modB = BridgeModule('modB');
+          // top is only needed to establish hierarchy for gets() validation.
+          // ignore: unused_local_variable
           final top = BridgeModule('top')
             ..addSubModule(modA)
             ..addSubModule(modB);
@@ -344,17 +346,43 @@ void main() {
           final receiverPort =
               modB.createPort('receiver', PortDirection.input, width: 8);
 
-          // enum should be silently ignored for non-same-module connections
-          connectPorts(driverPort, receiverPort, sameModuleConnectionType: ct);
-
-          // pullUpPort to top so build can succeed
-          top
-            ..pullUpPort(modA.createPort('dummyIn', PortDirection.input))
-            ..pullUpPort(modB.createPort('dummyOut', PortDirection.output));
-
-          await top.build();
+          expect(
+            () => connectPorts(driverPort, receiverPort,
+                sameModuleConnectionType: ct),
+            throwsA(isA<RohdBridgeException>()),
+          );
         });
       }
+
+      test('gives helpful message', () {
+        final modA = BridgeModule('modA');
+        final modB = BridgeModule('modB');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(modA)
+          ..addSubModule(modB);
+
+        final driverPort =
+            modA.createPort('driver', PortDirection.output, width: 8);
+        final receiverPort =
+            modB.createPort('receiver', PortDirection.input, width: 8);
+
+        expect(
+          () => connectPorts(driverPort, receiverPort,
+              sameModuleConnectionType: SameModuleConnectionType.loopback),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('only be provided'),
+                contains('same module'),
+              ),
+            ),
+          ),
+        );
+      });
     });
 
     group('error messages', () {

--- a/test/same_module_connection_test.dart
+++ b/test/same_module_connection_test.dart
@@ -539,5 +539,109 @@ void main() {
         );
       });
     });
+
+    group('signal routing verification', () {
+      test('inOut←inOut loopback routes through external ports', () async {
+        final mod = BridgeModule('mod');
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('driver', PortDirection.inOut, width: 8);
+        mod.createPort('receiver', PortDirection.inOut, width: 8).gets(driver,
+            sameModuleConnectionType: SameModuleConnectionType.loopback);
+        await top.build();
+
+        // External ports live on the parent module.
+        final driverExternal = mod.inOutSource('driver');
+        final receiverExternal = mod.inOutSource('receiver');
+        expect(driverExternal.parentModule, equals(top));
+        expect(receiverExternal.parentModule, equals(top));
+        expect(receiverExternal.srcConnections, contains(driverExternal));
+
+        // Internal path should NOT have a direct driver←driver connection.
+        expect(mod.inOut('receiver').srcConnections,
+            isNot(contains(mod.inOut('driver'))));
+      });
+
+      test('inOut←inOut passthrough routes through internal ports', () async {
+        final mod = BridgeModule('mod');
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('driver', PortDirection.inOut, width: 8);
+        mod.createPort('receiver', PortDirection.inOut, width: 8).gets(driver,
+            sameModuleConnectionType: SameModuleConnectionType.passthrough);
+        await top.build();
+
+        // Internal ports live on the module itself.
+        final driverInternal = mod.inOut('driver');
+        final receiverInternal = mod.inOut('receiver');
+        expect(driverInternal.parentModule, equals(mod));
+        expect(receiverInternal.parentModule, equals(mod));
+        expect(receiverInternal.srcConnections, contains(driverInternal));
+
+        // External path should NOT have the connection.
+        expect(mod.inOutSource('receiver').srcConnections,
+            isNot(contains(mod.inOutSource('driver'))));
+      });
+
+      test('inOut←output loopback routes through external ports', () async {
+        final mod = BridgeModule('mod');
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        mod.createPort('driver', PortDirection.output, width: 8);
+        mod.createPort('receiver', PortDirection.inOut, width: 8).gets(
+            mod.port('driver'),
+            sameModuleConnectionType: SameModuleConnectionType.loopback);
+        await top.build();
+
+        // Receiver external port lives on parent; driver output connects to it.
+        final receiverExternal = mod.inOutSource('receiver');
+        expect(receiverExternal.parentModule, equals(top));
+        expect(receiverExternal.srcConnections, contains(mod.output('driver')));
+      });
+
+      test('inOut←output passthrough routes through internal ports', () async {
+        final mod = BridgeModule('mod');
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        mod.createPort('driver', PortDirection.output, width: 8);
+        mod.createPort('receiver', PortDirection.inOut, width: 8).gets(
+            mod.port('driver'),
+            sameModuleConnectionType: SameModuleConnectionType.passthrough);
+        await top.build();
+
+        // Internal receiver lives on mod; driver output connects to it.
+        final receiverInternal = mod.inOut('receiver');
+        expect(receiverInternal.parentModule, equals(mod));
+        expect(receiverInternal.srcConnections, contains(mod.output('driver')));
+      });
+
+      test('output←inOut passthrough routes through internal ports', () async {
+        final mod = BridgeModule('mod');
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        mod.createPort('driver', PortDirection.inOut, width: 8);
+        mod.createPort('receiver', PortDirection.output, width: 8).gets(
+            mod.port('driver'),
+            sameModuleConnectionType: SameModuleConnectionType.passthrough);
+        await top.build();
+
+        // Output receiver is driven by the internal inOut port (on mod).
+        final receiverOut = mod.output('receiver');
+        final driverInternal = mod.inOut('driver');
+        expect(receiverOut.parentModule, equals(mod));
+        expect(driverInternal.parentModule, equals(mod));
+        expect(receiverOut.srcConnection, equals(driverInternal));
+      });
+    });
   });
 }

--- a/test/same_module_connection_test.dart
+++ b/test/same_module_connection_test.dart
@@ -1,0 +1,515 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// same_module_connection_test.dart
+// Tests for same-module connection disambiguation with
+// SameModuleConnectionType.
+//
+// 2026 April
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+/// Describes one combination in the same-module connection matrix.
+class _TestCase {
+  final PortDirection receiverDir;
+  final PortDirection driverDir;
+  final SameModuleConnectionType? connectionType;
+  final bool expectSuccess;
+
+  const _TestCase({
+    required this.receiverDir,
+    required this.driverDir,
+    required this.connectionType,
+    required this.expectSuccess,
+  });
+
+  @override
+  String toString() => '${receiverDir.name}←${driverDir.name}'
+      ' (${connectionType?.name ?? 'null'}):'
+      ' ${expectSuccess ? 'success' : 'fail'}';
+}
+
+/// All 27 test cases: 9 direction pairs × 3 enum values (null, loopback,
+/// passthrough).
+final _testCases = [
+  // input←input: always fails
+  for (final ct in _connectionTypes)
+    _TestCase(
+      receiverDir: PortDirection.input,
+      driverDir: PortDirection.input,
+      connectionType: ct,
+      expectSuccess: false,
+    ),
+
+  // input←output: default=loopback, loopback=ok, passthrough=fail
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.output,
+    connectionType: null,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.output,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.output,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: false,
+  ),
+
+  // input←inOut: default=loopback, loopback=ok, passthrough=fail
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.inOut,
+    connectionType: null,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.input,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: false,
+  ),
+
+  // output←input: default=passthrough, loopback=fail, passthrough=ok
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.input,
+    connectionType: null,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.input,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.input,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: true,
+  ),
+
+  // output←output: equivalent, all succeed
+  for (final ct in _connectionTypes)
+    _TestCase(
+      receiverDir: PortDirection.output,
+      driverDir: PortDirection.output,
+      connectionType: ct,
+      expectSuccess: true,
+    ),
+
+  // output←inOut: AMBIGUOUS, null=fail, loopback=fail (build rejects
+  // output driven by external inOut), passthrough=ok
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.inOut,
+    connectionType: null,
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.loopback,
+    // ROHD build rejects output driven by inOutSource (external net)
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.output,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: true,
+  ),
+
+  // inOut←input: default=passthrough, loopback=fail, passthrough=ok
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.input,
+    connectionType: null,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.input,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.input,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: true,
+  ),
+
+  // inOut←output: AMBIGUOUS, null=fail, both enum values succeed
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.output,
+    connectionType: null,
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.output,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.output,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: true,
+  ),
+
+  // inOut←inOut: AMBIGUOUS, null=fail, both enum values succeed
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.inOut,
+    connectionType: null,
+    expectSuccess: false,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.loopback,
+    expectSuccess: true,
+  ),
+  const _TestCase(
+    receiverDir: PortDirection.inOut,
+    driverDir: PortDirection.inOut,
+    connectionType: SameModuleConnectionType.passthrough,
+    expectSuccess: true,
+  ),
+];
+
+const _connectionTypes = [
+  null,
+  SameModuleConnectionType.loopback,
+  SameModuleConnectionType.passthrough,
+];
+
+void main() {
+  group('same module connection type', () {
+    group('gets()', () {
+      for (final tc in _testCases) {
+        test('gets: $tc', () async {
+          final mod = BridgeModule('testMod');
+          final top = BridgeModule('top')
+            ..addSubModule(mod)
+            ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+          final driverPort = mod.createPort('driver', tc.driverDir, width: 8);
+          final receiverPort =
+              mod.createPort('receiver', tc.receiverDir, width: 8);
+
+          if (tc.expectSuccess) {
+            receiverPort.gets(driverPort,
+                sameModuleConnectionType: tc.connectionType);
+            await top.build();
+          } else {
+            expect(
+              () => receiverPort.gets(driverPort,
+                  sameModuleConnectionType: tc.connectionType),
+              throwsA(isA<RohdBridgeException>()),
+            );
+          }
+        });
+      }
+    });
+
+    group('connectPorts()', () {
+      for (final tc in _testCases) {
+        // connectPorts does hierarchy punching; for same-module it passes
+        // through to gets().
+        test('connectPorts: $tc', () async {
+          final mod = BridgeModule('testMod');
+          final top = BridgeModule('top')
+            ..addSubModule(mod)
+            ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+          final driverPort = mod.createPort('driver', tc.driverDir, width: 8);
+          final receiverPort =
+              mod.createPort('receiver', tc.receiverDir, width: 8);
+
+          if (tc.expectSuccess) {
+            connectPorts(driverPort, receiverPort,
+                sameModuleConnectionType: tc.connectionType);
+            await top.build();
+          } else {
+            expect(
+              () => connectPorts(driverPort, receiverPort,
+                  sameModuleConnectionType: tc.connectionType),
+              throwsA(isA<RohdBridgeException>()),
+            );
+          }
+        });
+      }
+    });
+
+    group('sliced ports', () {
+      for (final ct in [
+        SameModuleConnectionType.loopback,
+        SameModuleConnectionType.passthrough,
+      ]) {
+        test('inOut←inOut sliced with ${ct.name}', () async {
+          final mod = BridgeModule('testMod');
+          final top = BridgeModule('top')
+            ..addSubModule(mod)
+            ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+          final driverPort =
+              mod.createPort('driver', PortDirection.inOut, width: 16);
+          final receiverPort =
+              mod.createPort('receiver', PortDirection.inOut, width: 16);
+
+          receiverPort
+              .slice(7, 0)
+              .gets(driverPort.slice(7, 0), sameModuleConnectionType: ct);
+          await top.build();
+        });
+
+        test('output←inOut sliced with ${ct.name}', () async {
+          final mod = BridgeModule('testMod');
+          final top = BridgeModule('top')
+            ..addSubModule(mod)
+            ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+          final driverPort =
+              mod.createPort('driver', PortDirection.inOut, width: 16);
+          final receiverPort =
+              mod.createPort('receiver', PortDirection.output, width: 16);
+
+          if (ct == SameModuleConnectionType.loopback) {
+            // loopback is invalid for output←inOut
+            expect(
+              () => receiverPort
+                  .slice(7, 0)
+                  .gets(driverPort.slice(7, 0), sameModuleConnectionType: ct),
+              throwsA(isA<RohdBridgeException>()),
+            );
+          } else {
+            receiverPort
+                .slice(7, 0)
+                .gets(driverPort.slice(7, 0), sameModuleConnectionType: ct);
+            await top.build();
+          }
+        });
+
+        test('inOut←output sliced with ${ct.name}', () async {
+          final mod = BridgeModule('testMod');
+          final top = BridgeModule('top')
+            ..addSubModule(mod)
+            ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+          final driverPort =
+              mod.createPort('driver', PortDirection.output, width: 16);
+          final receiverPort =
+              mod.createPort('receiver', PortDirection.inOut, width: 16);
+
+          receiverPort
+              .slice(7, 0)
+              .gets(driverPort.slice(7, 0), sameModuleConnectionType: ct);
+          await top.build();
+        });
+      }
+    });
+
+    group('non-same-module ignores enum', () {
+      for (final ct in [
+        SameModuleConnectionType.loopback,
+        SameModuleConnectionType.passthrough,
+      ]) {
+        test('sibling modules with ${ct.name}', () async {
+          final modA = BridgeModule('modA');
+          final modB = BridgeModule('modB');
+          final top = BridgeModule('top')
+            ..addSubModule(modA)
+            ..addSubModule(modB);
+
+          final driverPort =
+              modA.createPort('driver', PortDirection.output, width: 8);
+          final receiverPort =
+              modB.createPort('receiver', PortDirection.input, width: 8);
+
+          // enum should be silently ignored for non-same-module connections
+          connectPorts(driverPort, receiverPort, sameModuleConnectionType: ct);
+
+          // pullUpPort to top so build can succeed
+          top
+            ..pullUpPort(modA.createPort('dummyIn', PortDirection.input))
+            ..pullUpPort(modB.createPort('dummyOut', PortDirection.output));
+
+          await top.build();
+        });
+      }
+    });
+
+    group('error messages', () {
+      test('ambiguous inOut←inOut gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.inOut, width: 8);
+        final receiver = mod.createPort('r', PortDirection.inOut, width: 8);
+
+        expect(
+          () => receiver.gets(driver),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('ambiguous'),
+                contains('SameModuleConnectionType'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('ambiguous output←inOut gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.inOut, width: 8);
+        final receiver = mod.createPort('r', PortDirection.output, width: 8);
+
+        expect(
+          () => receiver.gets(driver),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              contains('ambiguous'),
+            ),
+          ),
+        );
+      });
+
+      test('ambiguous inOut←output gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.output, width: 8);
+        final receiver = mod.createPort('r', PortDirection.inOut, width: 8);
+
+        expect(
+          () => receiver.gets(driver),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              contains('ambiguous'),
+            ),
+          ),
+        );
+      });
+
+      test('wrong type for input←output gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.output, width: 8);
+        final receiver = mod.createPort('r', PortDirection.input, width: 8);
+
+        expect(
+          () => receiver.gets(driver,
+              sameModuleConnectionType: SameModuleConnectionType.passthrough),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('not valid'),
+                contains('loopback'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('wrong type for output←input gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.input, width: 8);
+        final receiver = mod.createPort('r', PortDirection.output, width: 8);
+
+        expect(
+          () => receiver.gets(driver,
+              sameModuleConnectionType: SameModuleConnectionType.loopback),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('not valid'),
+                contains('passthrough'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('loopback invalid for output←inOut gives helpful message', () {
+        final mod = BridgeModule('testMod');
+        // top is only needed to establish hierarchy for gets() validation.
+        // ignore: unused_local_variable
+        final top = BridgeModule('top')
+          ..addSubModule(mod)
+          ..pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+        final driver = mod.createPort('d', PortDirection.inOut, width: 8);
+        final receiver = mod.createPort('r', PortDirection.output, width: 8);
+
+        expect(
+          () => receiver.gets(driver,
+              sameModuleConnectionType: SameModuleConnectionType.loopback),
+          throwsA(
+            isA<RohdBridgeException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('not valid'),
+                contains('passthrough'),
+              ),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description & Motivation

This pull request introduces a new mechanism for handling ambiguous same-module port connections in the ROHD-Bridge codebase. Specifically, it adds the `SameModuleConnectionType` enum and requires explicit disambiguation when connecting ports on the same module involving `inOut` ports where directionality is not clear. The changes touch the core connection logic, update the API, and improve documentation and tests to reflect this new requirement.

Key changes include:

**API and Core Logic Enhancements:**

* Introduced the `SameModuleConnectionType` enum to distinguish between `loopback` (external-facing) and `passthrough` (internal-facing) connections for ambiguous same-module port connections, especially when at least one port is `inOut` and neither is `input`. The enum is now required in such cases for `gets()` and `connectPorts()` calls. [[1]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eR15-R39) [[2]](diffhunk://#diff-50611c8e07d0c8fc23c0e37482a69c07a7625f5f464333c7488ba34d64c97881R1112-R1126)
* Updated the `PortReference.gets` method and its internal logic to require and validate the `SameModuleConnectionType` for ambiguous cases, throwing exceptions when the type is omitted or invalid. This logic ensures safe, explicit connections and prevents ambiguous wiring. [[1]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL96-R127) [[2]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL162-R278)
* Modified the internal connection methods in `StandardPortReference` and `SlicePortReference` to propagate and respect the `SameModuleConnectionType` parameter, ensuring correct port subset selection for both external and internal connections. [[1]](diffhunk://#diff-887a77b748f20bf7d9bb8b061c0e84a290429086f02e469cdde482d12de775e5L47-R59) [[2]](diffhunk://#diff-57eeaba815c1dbc90110b62df102f2d072d2f5106e0e44f7ca873097d5a772d3L260-R266) [[3]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eR361-R366) [[4]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL304-R431) [[5]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eR464-R471)




<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->


<!-- Description of changes, and motivation for adding them. -->

## Related Issue(s)

N/A

## Testing

* Updated tests to require `SameModuleConnectionType` for ambiguous same-module connections, and added logic to expect failures when the enum is omitted in those cases. [[1]](diffhunk://#diff-e24f2c3b9ceda3e680bb279383fd9a335e9a94cd11295f60389f3627cba6af63L1059-R1060) [[2]](diffhunk://#diff-8ee890fc3b31a7c199e2331b25556411fa25f30369d03169f2fa5beb2201a087R201-R213)

These changes improve the safety and clarity of port connections within the same module, making ambiguous cases explicit and preventing subtle bugs.
## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

This could be understood as a bug -- ambiguous connections chose one way to make the connection, which may or may not have been the intent.  If code relied on the existing behavior, it will now see exceptions requiring more specificity.  It shouldn't silently break anything, only loudly.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

* Added comprehensive documentation to the `connectPorts` method and the new enum, clarifying when and why `SameModuleConnectionType` must be specified. [[1]](diffhunk://#diff-50611c8e07d0c8fc23c0e37482a69c07a7625f5f464333c7488ba34d64c97881R1112-R1126) [[2]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eR15-R39)