### PR TITLE
Fix bug where type mismatch connection extractor causes equality type error

### DIFF
--- a/lib/src/connection_extractor.dart
+++ b/lib/src/connection_extractor.dart
@@ -40,7 +40,7 @@ abstract class Connection<RefType extends Reference> {
   const Connection(this.point1, this.point2);
 
   /// Indicates whether [point] is one of the points in this connection.
-  bool hasPoint(RefType point) => point1 == point || point2 == point;
+  bool hasPoint(Reference point) => point1 == point || point2 == point;
 
   /// Indicates whether this connection involves the given [module] on either of
   /// its points.
@@ -61,7 +61,7 @@ abstract class Connection<RefType extends Reference> {
 
   @override
   bool operator ==(Object other) =>
-      other is Connection<RefType> &&
+      other is Connection<Reference> &&
       other.hasPoint(point1) &&
       other.hasPoint(point2);
 

--- a/test/connection_extractor_test.dart
+++ b/test/connection_extractor_test.dart
@@ -1113,6 +1113,39 @@ void main() {
         LogicValue.ofString('11'));
   });
 
+  test('connection equality between tie off and ad hoc is false', () async {
+    final top = BridgeModule('top');
+    final tiedOff = BridgeModule('tiedOff')
+      ..createPort('tiedInput', PortDirection.input)
+      ..createPort('tiedClk', PortDirection.input);
+    final src = BridgeModule('src')
+      ..createPort('dataOut', PortDirection.output)
+      ..createPort('srcClk', PortDirection.input);
+    final dst = BridgeModule('dst')..createPort('dataIn', PortDirection.input);
+    top
+      ..addSubModule(tiedOff)
+      ..addSubModule(src)
+      ..addSubModule(dst);
+
+    tiedOff.port('tiedClk').punchUpTo(top);
+    src.port('srcClk').punchUpTo(top);
+    tiedOff.port('tiedInput').tieOff(value: 1);
+    connectPorts(src.port('dataOut'), dst.port('dataIn'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+    final tieOffConnection =
+        extractor.connections.whereType<TieOffConnection>().single;
+    final adHocConnection = extractor.connections
+        .whereType<AdHocConnection>()
+        .firstWhere((connection) =>
+            connection.hasPoint(src.port('dataOut')) &&
+            connection.hasPoint(dst.port('dataIn')));
+
+    expect(tieOffConnection == adHocConnection, isFalse);
+  });
+
   test('connection extraction with consts pre-build', () {
     final top = BridgeModule('top');
     final subMod = BridgeModule('subMod');

--- a/test/connection_extractor_test.dart
+++ b/test/connection_extractor_test.dart
@@ -1143,7 +1143,7 @@ void main() {
             connection.hasPoint(src.port('dataOut')) &&
             connection.hasPoint(dst.port('dataIn')));
 
-    expect(tieOffConnection == adHocConnection, isFalse);
+    expect(tieOffConnection, isNot(equals(adHocConnection)));
   });
 
   test('connection extraction with consts pre-build', () {


### PR DESCRIPTION
## Description & Motivation

In some cases, the `ConnectionExtractor` could assume the wrong type during equality checks (calling `hasPoint`) causing errors such as:
```
_TypeError (type 'ConstReference' is not a subtype of type 'PortReference' of 'point')
```

This PR fixes that issue by loosening the type requirements on `hasPoint` and relying on equality checks on the points themselves.

## Related Issue(s)

N/A

## Testing

Added a new test which failed before the fix

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
