### PR TITLE
Support tryPort

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -680,6 +680,51 @@ class BridgeModule extends Module with SystemVerilog {
     return thisPort;
   }
 
+  /// Tries to create a port reference from a string representation with
+  /// advanced parsing.
+  ///
+  /// This method handles both simple ports and complex port references
+  /// including:
+  /// - Simple port names: "clk", "reset_n"
+  /// - Bit ranges and indices: "data[7:0]", "addr[5]"
+  /// - Struct member access: "mystruct.field" (using [structMap] lookup)
+  /// - Renamed ports: automatically resolves to original port names
+  ///
+  /// For struct ports (containing '.'), the method looks up the actual bit
+  /// slice in [structMap]. For renamed ports, it automatically resolves to the
+  /// original port name while preserving any range specification.
+  ///
+  /// Returns a [PortReference] that can be used for connections and operations,
+  /// or `null` if the referenced port access is valid but the port does not
+  /// exist.
+  ///
+  /// Throws an [Exception] if [portRefString] is not a valid port access
+  /// string.
+  PortReference? tryPort(String portRefString) {
+    if (portRefString.contains('.')) {
+      return structMap[portRefString];
+    }
+
+    final portRefComponents =
+        SlicePortReference.extractPortAccessSliceComponents(portRefString);
+
+    final portName = portRefComponents.portName;
+    final resolvedPortName = renamedPorts[portName] ?? portName;
+
+    if (tryInput(resolvedPortName) == null &&
+        tryOutput(resolvedPortName) == null &&
+        tryInOut(resolvedPortName) == null) {
+      return null;
+    }
+
+    if (renamedPorts.containsKey(portName)) {
+      return PortReference.fromString(
+          this, portRefString.replaceFirst(portName, resolvedPortName));
+    }
+
+    return PortReference.fromString(this, portRefString);
+  }
+
   /// Creates a port reference from a string representation with advanced
   /// parsing.
   ///
@@ -696,32 +741,11 @@ class BridgeModule extends Module with SystemVerilog {
   ///
   /// Returns a [PortReference] that can be used for connections and operations.
   ///
-  /// Throws an [Exception] if a struct port is not found in [structMap].
-  PortReference port(String portRefString) {
-    if (portRefString.contains('.')) {
-      // this is a struct port, special handling
-      if (!structMap.containsKey(portRefString)) {
-        throw RohdBridgeException(
-            'Struct port $portRefString not found in $name');
-      }
-
-      return structMap[portRefString]!;
-    } else {
-      final portRefComponents =
-          SlicePortReference.extractPortAccessSliceComponents(portRefString);
-
-      if (renamedPorts.containsKey(portRefComponents.portName)) {
-        return PortReference.fromString(
-            this,
-            portRefString.replaceFirst(
-              portRefComponents.portName,
-              renamedPorts[portRefComponents.portName]!,
-            ));
-      } else {
-        return PortReference.fromString(this, portRefString);
-      }
-    }
-  }
+  /// Throws an [Exception] if the port access string is invalid or the port is
+  /// not found.
+  PortReference port(String portRefString) =>
+      tryPort(portRefString) ??
+      (throw RohdBridgeException('Port $portRefString not found in $name'));
 
   /// Internal tracking map for hierarchical port connectivity optimization.
   ///

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -100,9 +100,15 @@ class InterfaceReference<InterfaceType extends PairInterface>
 
       for (final portName in internalInterface!.ports.keys) {
         final intfPortRef = port(portName);
+        final physicalPortName = portUniquify?.call(portName) ?? portName;
+        final physicalPortRef = module.tryPort(physicalPortName);
+
         _portMaps.add(
           PortMap(
-            port: module.port(portUniquify?.call(portName) ?? portName),
+            port: physicalPortRef ??
+                (intfPortRef.isDirectionless
+                    ? PortReference.fromString(module, physicalPortName)
+                    : module.port(physicalPortName)),
             interfacePort: intfPortRef,
             preConnected: true, // pre-resolved since we just connectIO'd
           ),

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -189,14 +189,24 @@ class InterfaceReference<InterfaceType extends PairInterface>
   @override
   int get hashCode => name.hashCode ^ module.hashCode ^ interface.hashCode;
 
-  /// Gets a reference to a specific port within this interface.
+  /// Tries to get a reference to a specific port within this interface.
   ///
   /// The [portRef] can be either a simple port name (e.g., "data") or include
   /// slicing/indexing syntax (e.g., "data[7:0]", "addr[3]").
   ///
   /// Returns either a [StandardInterfacePortReference] for simple port names or
-  /// a [SliceInterfacePortReference] for sliced access.
-  InterfacePortReference port(String portRef) {
+  /// a [SliceInterfacePortReference] for sliced access, or `null` if the
+  /// referenced port access is valid but the interface port does not exist.
+  ///
+  /// Throws an [Exception] if [portRef] is not a valid port access string.
+  InterfacePortReference? tryPort(String portRef) {
+    final portRefComponents =
+        SlicePortReference.extractPortAccessSliceComponents(portRef);
+
+    if (interface.tryPort(portRefComponents.portName) == null) {
+      return null;
+    }
+
     if (SlicePortReference._isSliceAccess(portRef)) {
       return SliceInterfacePortReference.fromString(this, portRef);
     }
@@ -207,6 +217,17 @@ class InterfaceReference<InterfaceType extends PairInterface>
 
     throw RohdBridgeException('Invalid port access string: $portRef');
   }
+
+  /// Gets a reference to a specific port within this interface.
+  ///
+  /// The [portRef] can be either a simple port name (e.g., "data") or include
+  /// slicing/indexing syntax (e.g., "data[7:0]", "addr[3]").
+  ///
+  /// Returns either a [StandardInterfacePortReference] for simple port names or
+  /// a [SliceInterfacePortReference] for sliced access.
+  InterfacePortReference port(String portRef) =>
+      tryPort(portRef) ??
+      (throw RohdBridgeException('Port $portRef not found on $this'));
 
   /// Creates a copy of this interface in a parent module.
   ///

--- a/test/intf_port_access_test.dart
+++ b/test/intf_port_access_test.dart
@@ -143,6 +143,17 @@ void main() {
     expect(BadMappingModule.new, throwsException);
   });
 
+  test('tryPort returns null for missing interface ports', () {
+    final intf = IntfPortAccessModule().interface('accessIntf');
+
+    expect(intf.tryPort('portFromConsumer'), intf.port('portFromConsumer'));
+    expect(intf.tryPort('portFromConsumer[3:0]'),
+        intf.port('portFromConsumer[3:0]'));
+    expect(intf.tryPort('missingPort'), isNull);
+    expect(intf.tryPort('missingPort[0]'), isNull);
+    expect(() => intf.tryPort('portFromConsumer[0:1:2]'), throwsException);
+  });
+
   group('slice function', () {
     test('intf normal to slice', () {
       final mod = IntfPortAccessModule();

--- a/test/port_access_test.dart
+++ b/test/port_access_test.dart
@@ -105,6 +105,22 @@ void main() {
       expect(p.portName, 'myPort');
     });
 
+    test('tryPort returns null for missing ports', () {
+      final mod = BridgeModule('mod')..addInput('myPort', null, width: 8);
+      mod
+        ..renamePort('myPort', 'renamedPort')
+        ..addStructMap('myStruct.field', mod.port('myPort[3:0]'));
+
+      expect(mod.tryPort('myPort'), mod.port('myPort'));
+      expect(mod.tryPort('renamedPort'), mod.port('renamedPort'));
+      expect(mod.tryPort('renamedPort[3:0]'), mod.port('renamedPort[3:0]'));
+      expect(mod.tryPort('myStruct.field'), mod.port('myStruct.field'));
+      expect(mod.tryPort('missingPort'), isNull);
+      expect(mod.tryPort('missingPort[0]'), isNull);
+      expect(mod.tryPort('myStruct.missing'), isNull);
+      expect(() => mod.tryPort('myPort[0:1:2]'), throwsException);
+    });
+
     group('port with slice access', () {
       test('single dimension', () {
         final p =


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds nullable `tryPort` accessors for both `BridgeModule` and `InterfaceReference`, making it easier for callers to check whether a port exists before using it.

The new `tryPort` APIs mirror the existing `port` behavior for valid references, including sliced ports, renamed ports, struct-mapped ports, and interface ports. The existing `port` methods now delegate to `tryPort` and throw when no matching port exists, keeping the throwing API behavior intact while centralizing the lookup logic.

Malformed port access strings still throw rather than returning `null`; `tryPort` only returns `null` when the reference syntax is valid but the requested port does not exist.

## Related Issue(s)
Fix #42 

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No, API docs updated automatically
