### PR TITLE
Simplify tieoff naming in generated SV

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -15,6 +15,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 // Use ROHD implementation imports for access to internal utilities.
 // ignore: implementation_imports
@@ -47,6 +48,8 @@ class BridgeModule extends Module with SystemVerilog {
       UnmodifiableListView(_definitionParameters);
   final List<SystemVerilogParameterDefinition> _definitionParameters;
 
+  final Map<LogicValue, Logic> _tieOffConstCache = {};
+
   /// Pass-through parameters used when instantiating this module in
   /// SystemVerilog.
   ///
@@ -69,6 +72,23 @@ class BridgeModule extends Module with SystemVerilog {
   // since we have a "normal" `instantiationVerilog` that has module
   // instantiation ports, we can accept empty port connections
   bool get acceptsEmptyPortConnections => true;
+
+  /// Returns the [Logic] to use for a tie-off to [value].
+  ///
+  /// Zero-valued tie-offs are intentionally left unnamed so generated
+  /// SystemVerilog can inline them. Non-zero tie-offs are cached by their
+  /// normalized [LogicValue] so repeated tie-offs share a readable constant.
+  @internal
+  Logic tieOffConst(dynamic value, {required int width, bool fill = false}) {
+    final constValue = Const(value, width: width, fill: fill);
+
+    if (constValue.value.isZero) {
+      return constValue;
+    }
+
+    return _tieOffConstCache.putIfAbsent(constValue.value,
+        () => constValue.named('tieoff_const$value', naming: Naming.mergeable));
+  }
 
   @override
   String instantiationVerilog(

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -500,8 +500,7 @@ sealed class PortReference extends Reference {
   /// as an integer, boolean, or [LogicValue]. If no value is provided, the port
   /// will be tied to 0.
   void tieOff({dynamic value = 0, bool fill = false}) {
-    getsLogic(Const(value, width: width, fill: fill)
-        .named('tieoff_const$value', naming: Naming.mergeable));
+    getsLogic(module.tieOffConst(value, width: width, fill: fill));
   }
 
   /// The bit width of this port reference.

--- a/test/tie_off_test.dart
+++ b/test/tie_off_test.dart
@@ -69,6 +69,38 @@ void main() {
     expect(mod.output('banana').value, LogicValue.of('10xz'));
   });
 
+  test('zero tieOffs do not introduce named constants in RTL', () async {
+    final mod = BridgeModule('mod')..addOutput('banana', width: 8);
+
+    for (var i = 0; i < mod.output('banana').width; i++) {
+      mod.port('banana[$i]').tieOff();
+    }
+
+    await mod.build();
+    final sv = mod.generateSynth();
+
+    expect(sv, isNot(contains('tieoff_const0')));
+    expect(mod.output('banana').value, LogicValue.filled(8, LogicValue.zero));
+  });
+
+  test('non-zero tieOffs preserve a shared readable constant in RTL', () async {
+    final mod = BridgeModule('mod')
+      ..addOutput('apple', width: 8)
+      ..addOutput('banana', width: 8);
+
+    mod.port('apple[7:0]').tieOff(value: 0x5a);
+    mod.port('banana[7:0]').tieOff(value: 0x5a);
+
+    await mod.build();
+    final sv = mod.generateSynth();
+
+    expect(RegExp("8'h5a").allMatches(sv), hasLength(1));
+    expect(sv, contains('tieoff_const90'));
+    expect(sv, isNot(contains('tieoff_const90_0')));
+    expect(mod.output('apple').value, LogicValue.ofInt(0x5a, 8));
+    expect(mod.output('banana').value, LogicValue.ofInt(0x5a, 8));
+  });
+
   test('tieOff with fill', () {
     final mod = BridgeModule('mod')
       ..addInput('apple', null, width: 8)


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Improves generated SystemVerilog for tieoffs by centralizing tieoff constant creation on BridgeModule.

- Zero-valued tieoffs now use unnamed Consts, allowing ROHD to inline them instead of emitting extra tieoff_const0 signals.
- Nonzero tieoffs are cached per module by normalized LogicValue, so repeated tieoffs to the same value share one readable named constant.
- PortReference.tieOff now delegates tieoff constant creation to an internal BridgeModule.tieOffConst helper.
- Added regression tests covering zero sliced tieoffs and repeated nonzero sliced tieoffs.


## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
