### PR TITLE
Add intermediateSignalName support for connectPorts and related methods

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1116,6 +1116,13 @@ class BridgeModule extends Module with SystemVerilog {
 /// disambiguate whether the connection is a [SameModuleConnectionType.loopback]
 /// (using external-facing ports) or a [SameModuleConnectionType.passthrough]
 /// (using internal-facing ports). See [PortReference.gets] for full details.
+///
+/// If [intermediateSignalName] is provided, an intermediate signal with that
+/// name is inserted on the direct (sibling-level) segment of the connection.
+/// This gives control over the name of the net that appears in the generated
+/// SystemVerilog. When multiple receivers share the same driver and
+/// [intermediateSignalName], the same intermediate signal is reused. The name
+/// is ignored for array-typed drivers or vertical (parent/child) connections.
 void connectPorts(
   PortReference driver,
   PortReference receiver, {

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1124,9 +1124,8 @@ void connectPorts(
   bool allowDriverPathUniquification = true,
   bool allowReceiverPathUniquification = true,
   SameModuleConnectionType? sameModuleConnectionType,
+  String? intermediateSignalName,
 }) {
-  // TODO(mkorbel1): need to add better control over naming of intermediate
-  //  ports -- default allow renaming? or should it prefer the top/leaf?
 
   if (driver.module.hasBuilt || receiver.module.hasBuilt) {
     throw RohdBridgeException('Cannot connect ports after build.');
@@ -1289,7 +1288,8 @@ void connectPorts(
   }
 
   receiverPortRef.gets(driverPortRef,
-      sameModuleConnectionType: sameModuleConnectionType);
+      sameModuleConnectionType: sameModuleConnectionType,
+      intermediateSignalName: intermediateSignalName);
 }
 
 /// Connects [intf1] to [intf2], creating all necessary ports through the

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1133,7 +1133,6 @@ void connectPorts(
   SameModuleConnectionType? sameModuleConnectionType,
   String? intermediateSignalName,
 }) {
-
   if (driver.module.hasBuilt || receiver.module.hasBuilt) {
     throw RohdBridgeException('Cannot connect ports after build.');
   }

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -315,8 +315,8 @@ sealed class PortReference extends Reference {
   /// For cases that cannot be cleanly represented by a single named signal
   /// (structured/array or list-typed drivers, or vertical connections),
   /// [driverValue] is returned unchanged and the connection remains unnamed.
-  dynamic _insertIntermediateSignalIfNeeded(
-      dynamic driverValue, String? intermediateSignalName, PortReference other) {
+  dynamic _insertIntermediateSignalIfNeeded(dynamic driverValue,
+      String? intermediateSignalName, PortReference other) {
     if (intermediateSignalName == null ||
         driverValue is! Logic ||
         driverValue is LogicArray ||
@@ -328,7 +328,7 @@ sealed class PortReference extends Reference {
     // Fan-out: reuse an existing net with this name already driven by the same
     // driver, so multiple receivers can share a single net.
     final existingNet = driverValue.dstConnections
-      .firstWhereOrNull((s) => !s.isPort && s.name == intermediateSignalName);
+        .firstWhereOrNull((s) => !s.isPort && s.name == intermediateSignalName);
     if (existingNet != null) {
       return existingNet;
     }

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -123,6 +123,11 @@ sealed class PortReference extends Reference {
   /// ambiguous (at least one port is [PortDirection.inOut] and neither is
   /// [PortDirection.input]), a [sameModuleConnectionType] must be provided to
   /// disambiguate.
+  ///
+  /// If [intermediateSignalName] is provided, an intermediate signal with that
+  /// name is inserted on sibling-level connections. See
+  /// [_insertIntermediateSignalIfNeeded] for details on when the name is
+  /// applied and when it is silently ignored.
   void gets(PortReference other,
       {SameModuleConnectionType? sameModuleConnectionType,
       String? intermediateSignalName}) {
@@ -284,29 +289,33 @@ sealed class PortReference extends Reference {
   }
 
   /// Implementation of [gets] after some validation.
+  ///
+  /// The [intermediateSignalName], if provided, is forwarded to
+  /// [_insertIntermediateSignalIfNeeded] so that a named intermediate signal
+  /// can be inserted on sibling-level connections.
   @internal
   void getsInternal(PortReference other,
       {SameModuleConnectionType? sameModuleConnectionType,
       String? intermediateSignalName});
 
   /// Returns the value that should drive the receiver for a connection sourced
-  /// from [driverValue], inserting a named intermediate net when requested.
+  /// from [driverValue], inserting a named intermediate signal when requested.
   ///
   /// When [intermediateSignalName] is provided and this is a sibling-level
   /// connection whose [driverValue] is a simple (non-array) [Logic], this
   /// creates a [Naming.renameable] intermediate signal (a [LogicNet] for
   /// bidirectional connections, otherwise a [Logic]) driven by [driverValue]
   /// and returns it, so the requested name appears in the generated
-  /// SystemVerilog. The width of the net matches [driverValue], which for a
+  /// SystemVerilog. The width of the signal matches [driverValue], which for a
   /// sliced driver is the width of the slice.
   ///
-  /// If a net with the same name already exists on the same [driverValue]
-  /// (fan-out), it is reused so multiple receivers share a single net.
+  /// If a signal with the same name already exists on the same [driverValue]
+  /// (fan-out), it is reused so multiple receivers share a single signal.
   ///
-  /// For cases that cannot be cleanly represented by a single named net (array
-  /// or list-typed drivers, or vertical connections), [driverValue] is returned
-  /// unchanged and the connection remains unnamed.
-  dynamic _insertIntermediateNetIfNeeded(
+  /// For cases that cannot be cleanly represented by a single named signal
+  /// (array or list-typed drivers, or vertical connections), [driverValue] is
+  /// returned unchanged and the connection remains unnamed.
+  dynamic _insertIntermediateSignalIfNeeded(
       dynamic driverValue, String? intermediateSignalName, PortReference other) {
     if (intermediateSignalName == null ||
         driverValue is! Logic ||

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -313,13 +313,14 @@ sealed class PortReference extends Reference {
   /// (fan-out), it is reused so multiple receivers share a single signal.
   ///
   /// For cases that cannot be cleanly represented by a single named signal
-  /// (array or list-typed drivers, or vertical connections), [driverValue] is
-  /// returned unchanged and the connection remains unnamed.
+  /// (structured/array or list-typed drivers, or vertical connections),
+  /// [driverValue] is returned unchanged and the connection remains unnamed.
   dynamic _insertIntermediateSignalIfNeeded(
       dynamic driverValue, String? intermediateSignalName, PortReference other) {
     if (intermediateSignalName == null ||
         driverValue is! Logic ||
         driverValue is LogicArray ||
+        driverValue is LogicStructure ||
         _relativeLocationOf(other) != _RelativePortLocation.sameLevel) {
       return driverValue;
     }

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -328,8 +328,7 @@ sealed class PortReference extends Reference {
     // Fan-out: reuse an existing net with this name already driven by the same
     // driver, so multiple receivers can share a single net.
     final existingNet = driverValue.dstConnections
-        .where((s) => !s.isPort && s.name == intermediateSignalName)
-        .firstOrNull;
+      .firstWhereOrNull((s) => !s.isPort && s.name == intermediateSignalName);
     if (existingNet != null) {
       return existingNet;
     }

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -124,7 +124,8 @@ sealed class PortReference extends Reference {
   /// [PortDirection.input]), a [sameModuleConnectionType] must be provided to
   /// disambiguate.
   void gets(PortReference other,
-      {SameModuleConnectionType? sameModuleConnectionType}) {
+      {SameModuleConnectionType? sameModuleConnectionType,
+      String? intermediateSignalName}) {
     final relativeLocation = _relativeLocationOf(other);
 
     if (relativeLocation == _RelativePortLocation.sameModule &&
@@ -207,7 +208,9 @@ sealed class PortReference extends Reference {
           _validateSameModuleConnectionType(other, sameModuleConnectionType);
     }
 
-    getsInternal(other, sameModuleConnectionType: resolvedConnectionType);
+    getsInternal(other,
+        sameModuleConnectionType: resolvedConnectionType,
+        intermediateSignalName: intermediateSignalName);
   }
 
   /// Validates and resolves the [SameModuleConnectionType] for a same-module
@@ -283,7 +286,56 @@ sealed class PortReference extends Reference {
   /// Implementation of [gets] after some validation.
   @internal
   void getsInternal(PortReference other,
-      {SameModuleConnectionType? sameModuleConnectionType});
+      {SameModuleConnectionType? sameModuleConnectionType,
+      String? intermediateSignalName});
+
+  /// Returns the value that should drive the receiver for a connection sourced
+  /// from [driverValue], inserting a named intermediate net when requested.
+  ///
+  /// When [intermediateSignalName] is provided and this is a sibling-level
+  /// connection whose [driverValue] is a simple (non-array) [Logic], this
+  /// creates a [Naming.renameable] intermediate signal (a [LogicNet] for
+  /// bidirectional connections, otherwise a [Logic]) driven by [driverValue]
+  /// and returns it, so the requested name appears in the generated
+  /// SystemVerilog. The width of the net matches [driverValue], which for a
+  /// sliced driver is the width of the slice.
+  ///
+  /// If a net with the same name already exists on the same [driverValue]
+  /// (fan-out), it is reused so multiple receivers share a single net.
+  ///
+  /// For cases that cannot be cleanly represented by a single named net (array
+  /// or list-typed drivers, or vertical connections), [driverValue] is returned
+  /// unchanged and the connection remains unnamed.
+  dynamic _insertIntermediateNetIfNeeded(
+      dynamic driverValue, String? intermediateSignalName, PortReference other) {
+    if (intermediateSignalName == null ||
+        driverValue is! Logic ||
+        driverValue is LogicArray ||
+        _relativeLocationOf(other) != _RelativePortLocation.sameLevel) {
+      return driverValue;
+    }
+
+    // Fan-out: reuse an existing net with this name already driven by the same
+    // driver, so multiple receivers can share a single net.
+    final existingNet = driverValue.dstConnections
+        .where((s) => !s.isPort && s.name == intermediateSignalName)
+        .firstOrNull;
+    if (existingNet != null) {
+      return existingNet;
+    }
+
+    final net = (driverValue.isNet || port.isNet)
+        ? LogicNet(
+            name: intermediateSignalName,
+            width: driverValue.width,
+            naming: Naming.renameable)
+        : Logic(
+            name: intermediateSignalName,
+            width: driverValue.width,
+            naming: Naming.renameable);
+    net <= driverValue;
+    return net;
+  }
 
   /// Connects this port to be driven by a [Logic] [other].
   ///

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -258,11 +258,12 @@ class SlicePortReference extends PortReference {
   @override
   @internal
   void getsInternal(PortReference other,
-      {SameModuleConnectionType? sameModuleConnectionType}) {
+      {SameModuleConnectionType? sameModuleConnectionType,
+      String? intermediateSignalName}) {
     var receiverPort = _relativeReceiverAndDriver(other,
             sameModuleConnectionType: sameModuleConnectionType)
         .receiver;
-    final otherDriver = _relativeDriverSubset(other,
+    var otherDriver = _relativeDriverSubset(other,
         sameModuleConnectionType: sameModuleConnectionType);
 
     int? leafIndex;
@@ -288,6 +289,13 @@ class SlicePortReference extends PortReference {
 
     assert(!((leafIndex != null) && hasSlicing),
         'cannot have both slicing and a leaf index');
+
+    // Insert a named intermediate net for simple (non-array) sibling slice
+    // connections, so the requested name appears in the generated
+    // SystemVerilog. The net is electrically a pass-through of the driver
+    // subset, so the downstream assignment logic remains correct.
+    otherDriver =
+        _insertIntermediateNetIfNeeded(otherDriver, intermediateSignalName, other);
 
     if (otherDriver is Logic) {
       if (leafIndex != null) {

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -290,12 +290,12 @@ class SlicePortReference extends PortReference {
     assert(!((leafIndex != null) && hasSlicing),
         'cannot have both slicing and a leaf index');
 
-    // Insert a named intermediate net for simple (non-array) sibling slice
+    // Insert a named intermediate signal for simple (non-array) sibling slice
     // connections, so the requested name appears in the generated
-    // SystemVerilog. The net is electrically a pass-through of the driver
+    // SystemVerilog. The signal is electrically a pass-through of the driver
     // subset, so the downstream assignment logic remains correct.
-    otherDriver =
-        _insertIntermediateNetIfNeeded(otherDriver, intermediateSignalName, other);
+    otherDriver = _insertIntermediateSignalIfNeeded(
+        otherDriver, intermediateSignalName, other);
 
     if (otherDriver is Logic) {
       if (leafIndex != null) {

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -45,15 +45,21 @@ class StandardPortReference extends PortReference {
   @override
   @internal
   void getsInternal(PortReference other,
-      {SameModuleConnectionType? sameModuleConnectionType}) {
+      {SameModuleConnectionType? sameModuleConnectionType,
+      String? intermediateSignalName}) {
     if (other is StandardPortReference) {
       final (receiver: receiver, driver: driver) = _relativeReceiverAndDriver(
           other,
           sameModuleConnectionType: sameModuleConnectionType);
-      receiver <= driver;
+      final effectiveDriver =
+          _insertIntermediateNetIfNeeded(driver, intermediateSignalName, other);
+      receiver <= (effectiveDriver as Logic);
     } else if (other is SlicePortReference) {
-      final otherDriver = _relativeDriverSubset(other,
-          sameModuleConnectionType: sameModuleConnectionType);
+      final otherDriver = _insertIntermediateNetIfNeeded(
+          _relativeDriverSubset(other,
+              sameModuleConnectionType: sameModuleConnectionType),
+          intermediateSignalName,
+          other);
       final receiver = _relativeReceiverAndDriver(other,
               sameModuleConnectionType: sameModuleConnectionType)
           .receiver;

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -51,11 +51,11 @@ class StandardPortReference extends PortReference {
       final (receiver: receiver, driver: driver) = _relativeReceiverAndDriver(
           other,
           sameModuleConnectionType: sameModuleConnectionType);
-      final effectiveDriver =
-          _insertIntermediateNetIfNeeded(driver, intermediateSignalName, other);
+      final effectiveDriver = _insertIntermediateSignalIfNeeded(
+          driver, intermediateSignalName, other);
       receiver <= (effectiveDriver as Logic);
     } else if (other is SlicePortReference) {
-      final otherDriver = _insertIntermediateNetIfNeeded(
+      final otherDriver = _insertIntermediateSignalIfNeeded(
           _relativeDriverSubset(other,
               sameModuleConnectionType: sameModuleConnectionType),
           intermediateSignalName,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rohd_bridge
 description: A ROHD-based framework for connectivity and assembly of hardware designs.
-version: 0.2.3
+version: 0.2.4
 homepage: https://intel.github.io/rohd-website
 repository: https://github.com/intel/rohd-bridge
 issue_tracker: https://github.com/intel/rohd-bridge/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rohd_bridge
 description: A ROHD-based framework for connectivity and assembly of hardware designs.
-version: 0.2.4
+version: 0.2.3
 homepage: https://intel.github.io/rohd-website
 repository: https://github.com/intel/rohd-bridge
 issue_tracker: https://github.com/intel/rohd-bridge/issues

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -40,6 +40,9 @@ void main() {
       await top.build();
       final sv = top.generateSynth();
       expect(sv, contains('myNamedNet'));
+
+      src.output('myPortOut').put(0xAB);
+      expect(dst.input('myPortIn').value.toInt(), equals(0xAB));
     });
 
     test('net name appears in portmap for both submodules', () async {
@@ -56,6 +59,9 @@ void main() {
       expect(sv, contains('sharedWire'));
       // dst's input port should be connected to sharedWire in the portmap
       expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*sharedWire\s*\)')));
+
+      src.output('myPortOut').put(0xA);
+      expect(dst.input('myPortIn').value.toInt(), equals(0xA));
     });
 
     test('without intermediateSignalName: connection works normally', () async {
@@ -70,6 +76,9 @@ void main() {
       final sv = top.generateSynth();
       // should compile, net name is auto-chosen
       expect(sv, isNotEmpty);
+
+      src.output('myPortOut').put(0xA);
+      expect(dst.input('myPortIn').value.toInt(), equals(0xA));
     });
 
     test('aligned slices: each half gets its own named net', () async {
@@ -98,6 +107,10 @@ void main() {
       // Lower net driven by the low half, upper net by the high half.
       expect(sv, matches(RegExp(r'myPortOutLower\s*=\s*myPortOut\[15:0\]')));
       expect(sv, matches(RegExp(r'myPortOutUpper\s*=\s*myPortOut\[31:16\]')));
+
+      // Verify all bits propagate correctly.
+      mod1.output('myPortOut').put(0xDEADBEEF);
+      expect(mod2.input('myPortIn').value.toInt(), equals(0xDEADBEEF));
     });
 
     test('driver slice into full receiver gets named net', () async {
@@ -116,6 +129,10 @@ void main() {
       expect(sv, matches(RegExp(r'logic\s*\[3:0\]\s*lowNibble')));
       expect(sv, matches(RegExp(r'lowNibble\s*=\s*myPortOut\[3:0\]')));
       expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*lowNibble\s*\)')));
+
+      // Low nibble (0xB) of 0xAB should appear on myPortIn.
+      src.output('myPortOut').put(0xAB);
+      expect(dst.input('myPortIn').value.toInt(), equals(0xB));
     });
 
     test('sibling inOut ports: net appears by name in generated SV', () async {
@@ -135,6 +152,9 @@ void main() {
       await top.build();
       final sv = top.generateSynth();
       expect(sv, contains('inoutBus'));
+
+      modA.port('portA').port.put(0xA);
+      expect(modB.port('portB').port.value.toInt(), equals(0xA));
     });
 
     test('fan-out: multiple receivers share one named net', () async {
@@ -175,6 +195,12 @@ void main() {
       expect(sv, matches(RegExp(r'\.myPortIn_b\s*\(\s*mySharedNet\s*\)')));
       expect(
           sv, matches(RegExp(r'\.myPortIn_c\s*\(\s*mySharedNet\s*\)')));
+
+      // All three receivers should see the driven value.
+      src.output('myPortOut').put(1);
+      expect(dst1.input('myPortIn_a').value.toInt(), equals(1));
+      expect(dst2.input('myPortIn_b').value.toInt(), equals(1));
+      expect(dst3.input('myPortIn_c').value.toInt(), equals(1));
     });
 
     test('name collision auto-uniquifies (Naming.renameable)', () async {
@@ -210,6 +236,12 @@ void main() {
           reason: 'at least one net should use the requested name');
       expect(sv, matches(RegExp(r'mySharedNet_\d+')),
           reason: 'second net with colliding name should be uniquified');
+
+      // Each src should independently drive its intended dst.
+      src.output('myPortOut1').put(0xAB);
+      src.output('myPortOut2').put(0xCD);
+      expect(dst1.input('myPortIn').value.toInt(), equals(0xAB));
+      expect(dst2.input('myPortIn').value.toInt(), equals(0xCD));
     });
 
     test('vertical connection: intermediateSignalName is ignored (no-op)',
@@ -223,9 +255,12 @@ void main() {
 
       // intermediateSignalName is silently ignored for non-sibling connections;
       // connectPorts handles the vertical punch-up as normal.
-      // Should not throw.
+      // Should not throw, and signal should still propagate.
       connectPorts(grandParent.port('clk'), child.port('clk'),
           intermediateSignalName: 'clkRouted');
+
+      grandParent.input('clk').put(1);
+      expect(child.input('clk').value.toInt(), equals(1));
 
       await grandParent.build();
     });

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -43,10 +43,11 @@ void main() {
 
       // The intermediate signal should exist in top's internal signals,
       // driven by src's output and driving dst's input source.
-      final intermediate = top.internalSignals
-          .firstWhere((s) => s.name == 'myNamedNet');
+      final intermediate =
+          top.internalSignals.firstWhere((s) => s.name == 'myNamedNet');
       expect(intermediate.srcConnections, contains(src.output('myPortOut')));
-      expect(dst.inputSource('myPortIn').srcConnections, contains(intermediate));
+      expect(
+          dst.inputSource('myPortIn').srcConnections, contains(intermediate));
 
       src.output('myPortOut').put(0xAB);
       expect(dst.input('myPortIn').value.toInt(), equals(0xAB));
@@ -98,11 +99,9 @@ void main() {
       mod2.createPort('myPortIn', PortDirection.input, width: 32);
       top.pullUpPort(mod1.createPort('dummy', PortDirection.output));
 
-      connectPorts(
-          mod1.port('myPortOut[15:0]'), mod2.port('myPortIn[15:0]'),
+      connectPorts(mod1.port('myPortOut[15:0]'), mod2.port('myPortIn[15:0]'),
           intermediateSignalName: 'myPortOutLower');
-      connectPorts(
-          mod1.port('myPortOut[31:16]'), mod2.port('myPortIn[31:16]'),
+      connectPorts(mod1.port('myPortOut[31:16]'), mod2.port('myPortIn[31:16]'),
           intermediateSignalName: 'myPortOutUpper');
 
       await top.build();
@@ -201,8 +200,7 @@ void main() {
       // All three inputs should be connected to mySharedNet in the portmaps.
       expect(sv, matches(RegExp(r'\.myPortIn_a\s*\(\s*mySharedNet\s*\)')));
       expect(sv, matches(RegExp(r'\.myPortIn_b\s*\(\s*mySharedNet\s*\)')));
-      expect(
-          sv, matches(RegExp(r'\.myPortIn_c\s*\(\s*mySharedNet\s*\)')));
+      expect(sv, matches(RegExp(r'\.myPortIn_c\s*\(\s*mySharedNet\s*\)')));
 
       // All three receivers should see the driven value.
       src.output('myPortOut').put(1);
@@ -258,7 +256,7 @@ void main() {
       final parent = grandParent.addSubModule(BridgeModule('parent'));
       final child = parent.addSubModule(BridgeModule('child'))
         ..createPort('clk', PortDirection.input);
-      
+
       grandParent.createPort('clk', PortDirection.input);
 
       // intermediateSignalName is silently ignored for non-sibling connections;

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// intermediate_signal_name_test.dart
+// Tests for the intermediateSignalName parameter on connectPorts.
+//
+// 2026 July
+// Author: Adin De'Rosier <adin.derosier@intel.com>
+
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+/// Sets up a top module with src and dst submodules, each with a
+/// dummy output so ROHD can trace both submodules during build.
+({BridgeModule top, BridgeModule src, BridgeModule dst}) _buildRig(
+    {int width = 8}) {
+  final top = BridgeModule('top');
+  final src = top.addSubModule(BridgeModule('src'));
+  final dst = top.addSubModule(BridgeModule('dst'));
+
+  // dummy outputs so top can trace both submodules during build
+  top
+    ..pullUpPort(src.createPort('dummy', PortDirection.output))
+    ..pullUpPort(dst.createPort('dummy', PortDirection.output));
+
+  return (top: top, src: src, dst: dst);
+}
+
+void main() {
+  group('intermediateSignalName on connectPorts', () {
+    test('sibling logic ports: net appears by name in generated SV', () async {
+      final (:top, :src, :dst) = _buildRig();
+
+      src.createPort('myPortOut', PortDirection.output, width: 8);
+      dst.createPort('myPortIn', PortDirection.input, width: 8);
+
+      connectPorts(src.port('myPortOut'), dst.port('myPortIn'),
+          intermediateSignalName: 'myNamedNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+      expect(sv, contains('myNamedNet'));
+    });
+
+    test('net name appears in portmap for both submodules', () async {
+      final (:top, :src, :dst) = _buildRig(width: 4);
+
+      src.createPort('myPortOut', PortDirection.output, width: 4);
+      dst.createPort('myPortIn', PortDirection.input, width: 4);
+
+      connectPorts(src.port('myPortOut'), dst.port('myPortIn'),
+          intermediateSignalName: 'sharedWire');
+
+      await top.build();
+      final sv = top.generateSynth();
+      expect(sv, contains('sharedWire'));
+      // dst's input port should be connected to sharedWire in the portmap
+      expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*sharedWire\s*\)')));
+    });
+
+    test('without intermediateSignalName: connection works normally', () async {
+      final (:top, :src, :dst) = _buildRig(width: 4);
+
+      src.createPort('myPortOut', PortDirection.output, width: 4);
+      dst.createPort('myPortIn', PortDirection.input, width: 4);
+
+      connectPorts(src.port('myPortOut'), dst.port('myPortIn'));
+
+      await top.build();
+      final sv = top.generateSynth();
+      // should compile, net name is auto-chosen
+      expect(sv, isNotEmpty);
+    });
+
+    test('aligned slices: each half gets its own named net', () async {
+      final top = BridgeModule('top');
+      final mod1 = top.addSubModule(BridgeModule('mod1'));
+      final mod2 = top.addSubModule(BridgeModule('mod2'));
+
+      mod1.createPort('myPortOut', PortDirection.output, width: 32);
+      mod2.createPort('myPortIn', PortDirection.input, width: 32);
+      top.pullUpPort(mod1.createPort('dummy', PortDirection.output));
+
+      connectPorts(
+          mod1.port('myPortOut[15:0]'), mod2.port('myPortIn[15:0]'),
+          intermediateSignalName: 'myPortOutLower');
+      connectPorts(
+          mod1.port('myPortOut[31:16]'), mod2.port('myPortIn[31:16]'),
+          intermediateSignalName: 'myPortOutUpper');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      // Both named nets exist and are 16 bits wide.
+      expect(sv, matches(RegExp(r'logic\s*\[15:0\]\s*myPortOutLower')));
+      expect(sv, matches(RegExp(r'logic\s*\[15:0\]\s*myPortOutUpper')));
+
+      // Lower net driven by the low half, upper net by the high half.
+      expect(sv, matches(RegExp(r'myPortOutLower\s*=\s*myPortOut\[15:0\]')));
+      expect(sv, matches(RegExp(r'myPortOutUpper\s*=\s*myPortOut\[31:16\]')));
+    });
+
+    test('driver slice into full receiver gets named net', () async {
+      final (:top, :src, :dst) = _buildRig();
+
+      src.createPort('myPortOut', PortDirection.output, width: 8);
+      dst.createPort('myPortIn', PortDirection.input, width: 4);
+
+      connectPorts(src.port('myPortOut[3:0]'), dst.port('myPortIn'),
+          intermediateSignalName: 'lowNibble');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      // 4-bit named net driven by the low nibble of myPortOut.
+      expect(sv, matches(RegExp(r'logic\s*\[3:0\]\s*lowNibble')));
+      expect(sv, matches(RegExp(r'lowNibble\s*=\s*myPortOut\[3:0\]')));
+      expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*lowNibble\s*\)')));
+    });
+
+    test('sibling inOut ports: net appears by name in generated SV', () async {
+      final top = BridgeModule('top');
+      final modA = top.addSubModule(BridgeModule('modA'));
+      final modB = top.addSubModule(BridgeModule('modB'));
+
+      modA.createPort('portA', PortDirection.inOut, width: 4);
+      modB.createPort('portB', PortDirection.inOut, width: 4);
+
+      // pull the inOut up to top so it's traceable
+      top.pullUpPort(modA.port('portA'));
+
+      connectPorts(modA.port('portA'), modB.port('portB'),
+          intermediateSignalName: 'inoutBus');
+
+      await top.build();
+      final sv = top.generateSynth();
+      expect(sv, contains('inoutBus'));
+    });
+
+    test('fan-out: multiple receivers share one named net', () async {
+      final top = BridgeModule('top');
+      final src = top.addSubModule(BridgeModule('src'));
+      final dst1 = top.addSubModule(BridgeModule('dst1'));
+      final dst2 = top.addSubModule(BridgeModule('dst2'));
+      final dst3 = top.addSubModule(BridgeModule('dst3'));
+
+      src.createPort('myPortOut', PortDirection.output);
+      dst1.createPort('myPortIn_a', PortDirection.input);
+      dst2.createPort('myPortIn_b', PortDirection.input);
+      dst3.createPort('myPortIn_c', PortDirection.input);
+
+      top
+        ..pullUpPort(src.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst1.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst2.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst3.createPort('dummy', PortDirection.output));
+
+      // All three connections request the same net name from the same driver.
+      connectPorts(src.port('myPortOut'), dst1.port('myPortIn_a'),
+          intermediateSignalName: 'mySharedNet');
+      connectPorts(src.port('myPortOut'), dst2.port('myPortIn_b'),
+          intermediateSignalName: 'mySharedNet');
+      connectPorts(src.port('myPortOut'), dst3.port('myPortIn_c'),
+          intermediateSignalName: 'mySharedNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      // Only one net declaration — not mySharedNet_0 or mySharedNet_1.
+      expect(sv, contains('mySharedNet'));
+      expect(sv, isNot(contains('mySharedNet_0')),
+          reason: 'fan-out should reuse the same net, not uniquify');
+      // All three inputs should be connected to mySharedNet in the portmaps.
+      expect(sv, matches(RegExp(r'\.myPortIn_a\s*\(\s*mySharedNet\s*\)')));
+      expect(sv, matches(RegExp(r'\.myPortIn_b\s*\(\s*mySharedNet\s*\)')));
+      expect(
+          sv, matches(RegExp(r'\.myPortIn_c\s*\(\s*mySharedNet\s*\)')));
+    });
+
+    test('name collision auto-uniquifies (Naming.renameable)', () async {
+      final top = BridgeModule('top');
+      final src = top.addSubModule(BridgeModule('src'));
+      final dst1 = top.addSubModule(BridgeModule('dst1'));
+      final dst2 = top.addSubModule(BridgeModule('dst2'));
+
+      src
+        ..createPort('myPortOut1', PortDirection.output, width: 8)
+        ..createPort('myPortOut2', PortDirection.output, width: 8);
+      dst1.createPort('myPortIn', PortDirection.input, width: 8);
+      dst2.createPort('myPortIn', PortDirection.input, width: 8);
+
+      // dummy outputs for traceability
+      top
+        ..pullUpPort(src.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst1.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst2.createPort('dummy', PortDirection.output));
+
+      // Both connections request the same net name; the second gets uniquified.
+      connectPorts(src.port('myPortOut1'), dst1.port('myPortIn'),
+          intermediateSignalName: 'mySharedNet');
+      connectPorts(src.port('myPortOut2'), dst2.port('myPortIn'),
+          intermediateSignalName: 'mySharedNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      // The first connection should keep the base name; the second should be
+      // uniquified to mySharedNet_0, mySharedNet_1, etc.
+      expect(sv, contains('mySharedNet'),
+          reason: 'at least one net should use the requested name');
+      expect(sv, matches(RegExp(r'mySharedNet_\d+')),
+          reason: 'second net with colliding name should be uniquified');
+    });
+
+    test('vertical connection: intermediateSignalName is ignored (no-op)',
+        () async {
+      final grandParent = BridgeModule('grandParent');
+      final parent = grandParent.addSubModule(BridgeModule('parent'));
+      final child = parent.addSubModule(BridgeModule('child'))
+        ..createPort('clk', PortDirection.input);
+      
+      grandParent.createPort('clk', PortDirection.input);
+
+      // intermediateSignalName is silently ignored for non-sibling connections;
+      // connectPorts handles the vertical punch-up as normal.
+      // Should not throw.
+      connectPorts(grandParent.port('clk'), child.port('clk'),
+          intermediateSignalName: 'clkRouted');
+
+      await grandParent.build();
+    });
+  });
+}

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -41,6 +41,13 @@ void main() {
       final sv = top.generateSynth();
       expect(sv, contains('myNamedNet'));
 
+      // The intermediate signal should exist in top's internal signals,
+      // driven by src's output and driving dst's input source.
+      final intermediate = top.internalSignals
+          .firstWhere((s) => s.name == 'myNamedNet');
+      expect(intermediate.srcConnections, contains(src.output('myPortOut')));
+      expect(dst.inputSource('myPortIn').srcConnections, contains(intermediate));
+
       src.output('myPortOut').put(0xAB);
       expect(dst.input('myPortIn').value.toInt(), equals(0xAB));
     });
@@ -57,7 +64,8 @@ void main() {
       await top.build();
       final sv = top.generateSynth();
       expect(sv, contains('sharedWire'));
-      // dst's input port should be connected to sharedWire in the portmap
+      // The net should appear in both submodules' portmaps.
+      expect(sv, matches(RegExp(r'\.myPortOut\s*\(\s*sharedWire\s*\)')));
       expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*sharedWire\s*\)')));
 
       src.output('myPortOut').put(0xA);


### PR DESCRIPTION
This pull request introduces support for explicitly naming intermediate nets created during port connections in the `rohd_bridge` package. The main addition is the optional `intermediateSignalName` parameter to `connectPorts` and related internal APIs, allowing users to request a specific name for the generated net in SystemVerilog, improving readability and traceability in generated code. Comprehensive tests are also added to verify the new behavior.

**New Feature: Named Intermediate Nets**
- Added `intermediateSignalName` parameter to `connectPorts` and propagated it through the port connection logic, enabling users to specify the name of the intermediate net created for sibling-level connections. [[1]](diffhunk://#diff-50611c8e07d0c8fc23c0e37482a69c07a7625f5f464333c7488ba34d64c97881R1127-L1129) [[2]](diffhunk://#diff-50611c8e07d0c8fc23c0e37482a69c07a7625f5f464333c7488ba34d64c97881L1292-R1292) [[3]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL127-R128) [[4]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL210-R213) [[5]](diffhunk://#diff-57eeaba815c1dbc90110b62df102f2d072d2f5106e0e44f7ca873097d5a772d3L261-R266) [[6]](diffhunk://#diff-57eeaba815c1dbc90110b62df102f2d072d2f5106e0e44f7ca873097d5a772d3R293-R299) [[7]](diffhunk://#diff-887a77b748f20bf7d9bb8b061c0e84a290429086f02e469cdde482d12de775e5L48-R62)

**Implementation Details**
- Implemented the `_insertIntermediateSignalIfNeeded` method in `PortReference`, which creates or reuses a named net for simple (non-array) sibling connections. Handles fan-out by sharing the net among multiple receivers and auto-uniquifies names on collision. [[1]](diffhunk://#diff-33444081d94c16c8747812ce3fbf4e2bd1bd1c77f8eab2a63aa1ed181847a52eL286-R338) [[2]](diffhunk://#diff-57eeaba815c1dbc90110b62df102f2d072d2f5106e0e44f7ca873097d5a772d3R293-R299) [[3]](diffhunk://#diff-887a77b748f20bf7d9bb8b061c0e84a290429086f02e469cdde482d12de775e5L48-R62)

**Testing**
- Added a dedicated test suite `intermediate_signal_name_test.dart` to verify that named nets appear as expected in generated SystemVerilog, including cases for slices, fan-out, name collisions, and vertical connections where naming is ignored.

These changes provide finer control over net naming in generated code, which is especially useful for debugging and for meeting integration requirements with external tools or flows.