### PR TITLE
Fix `buildAndGenerateRTL` file naming for uniquified modules

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -995,13 +995,16 @@ class BridgeModule extends Module with SystemVerilog {
     final filelistContents = StringBuffer();
     logger.sectionSeparator('Generating RTL');
     final fileIoFutures = <Future<void>>[];
-    for (final synthResult in synthResults) {
-      final fileName = '${synthResult.module.definitionName}.sv';
+    final synthFiles = synthResults
+        .expand((synthResult) => synthResult.toSynthFileContents())
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    for (final synthFile in synthFiles) {
+      final fileName = '${synthFile.name}.sv';
       final filePath = '$outputGenerationPath/$fileName';
       filelistContents.writeln('./rtl/$fileName');
 
-      fileIoFutures.add(File(filePath)
-          .writeAsString(synthResult.toSynthFileContents().join('\n')));
+      fileIoFutures.add(File(filePath).writeAsString(synthFile.contents));
 
       logger.finer('Generated file ${Directory(filePath).absolute.path}');
     }

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -995,10 +995,8 @@ class BridgeModule extends Module with SystemVerilog {
     final filelistContents = StringBuffer();
     logger.sectionSeparator('Generating RTL');
     final fileIoFutures = <Future<void>>[];
-    final synthFiles = synthResults
-        .expand((synthResult) => synthResult.toSynthFileContents())
-        .toList()
-      ..sort((a, b) => a.name.compareTo(b.name));
+    final synthFiles =
+        synthResults.expand((synthResult) => synthResult.toSynthFileContents());
     for (final synthFile in synthFiles) {
       final fileName = '${synthFile.name}.sv';
       final filePath = '$outputGenerationPath/$fileName';

--- a/test/build_and_generate_rtl_test.dart
+++ b/test/build_and_generate_rtl_test.dart
@@ -14,7 +14,7 @@ import 'package:rohd_bridge/rohd_bridge.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('uses uniquified synthesis names for generated RTL files', () async {
+  test('uses synthesis order and uniquified names for RTL files', () async {
     final output = await Directory.systemTemp.createTemp('rohd_bridge_rtl_');
     addTearDown(() => output.delete(recursive: true));
 
@@ -30,7 +30,7 @@ void main() {
       reserveDefinitionName: false,
     )..createPort('data', PortDirection.output, width: 16);
 
-    final top = BridgeModule('top')
+    final top = BridgeModule('aaa_top')
       ..addSubModule(leaf8)
       ..addSubModule(leaf16)
       ..pullUpPort(leaf8.port('data'))
@@ -40,7 +40,10 @@ void main() {
 
     final filelist = await File('${output.path}/filelist.f').readAsLines();
 
-    expect(filelist, ['./rtl/leaf.sv', './rtl/leaf_0.sv', './rtl/top.sv']);
+    expect(
+      filelist,
+      ['./rtl/leaf.sv', './rtl/leaf_0.sv', './rtl/aaa_top.sv'],
+    );
     expect(File('${output.path}/rtl/leaf_0.sv').existsSync(), isTrue);
   });
 }

--- a/test/build_and_generate_rtl_test.dart
+++ b/test/build_and_generate_rtl_test.dart
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// build_and_generate_rtl_test.dart
+// Tests to ensure that buildAndGenerateRTL works as expected.
+//
+// 2026 July 10
+// Authors:
+//   Max Korbel <max.korbel@intel.com>
+
+import 'dart:io';
+
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('uses uniquified synthesis names for generated RTL files', () async {
+    final output = await Directory.systemTemp.createTemp('rohd_bridge_rtl_');
+    addTearDown(() => output.delete(recursive: true));
+
+    final leaf8 = BridgeModule(
+      'leaf',
+      name: 'leaf8',
+      reserveDefinitionName: false,
+    )..createPort('data', PortDirection.output, width: 8);
+
+    final leaf16 = BridgeModule(
+      'leaf',
+      name: 'leaf16',
+      reserveDefinitionName: false,
+    )..createPort('data', PortDirection.output, width: 16);
+
+    final top = BridgeModule('top')
+      ..addSubModule(leaf8)
+      ..addSubModule(leaf16)
+      ..pullUpPort(leaf8.port('data'))
+      ..pullUpPort(leaf16.port('data'));
+
+    await top.buildAndGenerateRTL(outputPath: output.path);
+
+    final filelist = await File('${output.path}/filelist.f').readAsLines();
+
+    expect(filelist, ['./rtl/leaf.sv', './rtl/leaf_0.sv', './rtl/top.sv']);
+    expect(File('${output.path}/rtl/leaf_0.sv').existsSync(), isTrue);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Update `BridgeModule.buildAndGenerateRTL` to generate RTL files from the `SynthFileContents` artifacts returned by ROHD.

Each artifact is now written using its uniquified `SynthFileContents.name`.

Previously, files were named using the original module `definitionName`. Non-equivalent modules sharing that name could therefore produce duplicate filelist entries and concurrently overwrite the same output file.

## Related Issue(s)

N/A

## Testing

Added a new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
