### PR TITLE
Resolve deferred port maps for mapped interface port operations

### DIFF
--- a/lib/src/references/interface_port_reference.dart
+++ b/lib/src/references/interface_port_reference.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface_port_reference.dart

--- a/lib/src/references/interface_port_reference.dart
+++ b/lib/src/references/interface_port_reference.dart
@@ -86,8 +86,9 @@ mixin InterfacePortReference on PortReference {
       !_isFromConsumer;
 
   /// Activates deferred port maps whose logical interface port overlaps this
-  /// reference, so tying off a mapped interface port drives the physical port.
-  void _connectPortMapsForTieOff() {
+  /// reference before treating it as a concrete port operation endpoint.
+  @override
+  void _connectOverlappingInterfacePortMaps() {
     for (final portMap in interfaceReference.portMaps
         .where((portMap) => _overlaps(portMap.interfacePort))) {
       portMap.connect();

--- a/lib/src/references/interface_port_reference.dart
+++ b/lib/src/references/interface_port_reference.dart
@@ -85,6 +85,15 @@ mixin InterfacePortReference on PortReference {
       !_isFromProvider &&
       !_isFromConsumer;
 
+  /// Activates deferred port maps whose logical interface port overlaps this
+  /// reference, so tying off a mapped interface port drives the physical port.
+  void _connectPortMapsForTieOff() {
+    for (final portMap in interfaceReference.portMaps
+        .where((portMap) => _overlaps(portMap.interfacePort))) {
+      portMap.connect();
+    }
+  }
+
   /// Provides a reference to a [Logic] on an interface in this reference.
   ///
   /// For inputs and inOuts, this is the internal interface port if it exists.

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -213,6 +213,9 @@ sealed class PortReference extends Reference {
           _validateSameModuleConnectionType(other, sameModuleConnectionType);
     }
 
+    _connectOverlappingInterfacePortMaps();
+    other._connectOverlappingInterfacePortMaps();
+
     getsInternal(other,
         sameModuleConnectionType: resolvedConnectionType,
         intermediateSignalName: intermediateSignalName);
@@ -385,6 +388,10 @@ sealed class PortReference extends Reference {
     return thisRange.lower <= otherRange.upper &&
         otherRange.lower <= thisRange.upper;
   }
+
+  /// Activates any deferred port maps that should be resolved before this
+  /// reference is used as a concrete port operation endpoint.
+  void _connectOverlappingInterfacePortMaps() {}
 
   /// Gets a single bit of this port at the specified [index].
   ///
@@ -581,9 +588,7 @@ sealed class PortReference extends Reference {
   /// as an integer, boolean, or [LogicValue]. If no value is provided, the port
   /// will be tied to 0.
   void tieOff({dynamic value = 0, bool fill = false}) {
-    if (this case final InterfacePortReference intfPort) {
-      intfPort._connectPortMapsForTieOff();
-    }
+    _connectOverlappingInterfacePortMaps();
 
     getsLogic(module.tieOffConst(value, width: width, fill: fill));
   }
@@ -617,6 +622,8 @@ sealed class PortReference extends Reference {
           'Cannot punch up to a module that is not a parent.');
     }
 
+    _connectOverlappingInterfacePortMaps();
+
     if (!parentModule.subModules.contains(module)) {
       return parentModule.pullUpPort(this, newPortName: newPortName);
     }
@@ -646,6 +653,8 @@ sealed class PortReference extends Reference {
       throw RohdBridgeException(
           'Cannot punch down to a module that is not a submodule.');
     }
+
+    _connectOverlappingInterfacePortMaps();
 
     // make a new port in the same direction on new module
     final newPortRef =

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -366,6 +366,26 @@ sealed class PortReference extends Reference {
   /// reference to bits 7 through 0 of the port.
   PortReference slice(int endIndex, int startIndex);
 
+  /// The inclusive bit range of this reference within the flattened port.
+  ///
+  /// This is used to compare standard and sliced references that point into
+  /// the same base port.
+  ({int lower, int upper}) get _flatRange;
+
+  /// Whether this reference and [other] select any common bits of the same
+  /// port on the same module.
+  bool _overlaps(PortReference other) {
+    if (module != other.module || portName != other.portName) {
+      return false;
+    }
+
+    final thisRange = _flatRange;
+    final otherRange = other._flatRange;
+
+    return thisRange.lower <= otherRange.upper &&
+        otherRange.lower <= thisRange.upper;
+  }
+
   /// Gets a single bit of this port at the specified [index].
   ///
   /// This is equivalent to calling `slice(index, index)`.
@@ -561,6 +581,10 @@ sealed class PortReference extends Reference {
   /// as an integer, boolean, or [LogicValue]. If no value is provided, the port
   /// will be tied to 0.
   void tieOff({dynamic value = 0, bool fill = false}) {
+    if (this case final InterfacePortReference intfPort) {
+      intfPort._connectPortMapsForTieOff();
+    }
+
     getsLogic(module.tieOffConst(value, width: width, fill: fill));
   }
 

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -530,11 +530,15 @@ class SlicePortReference extends PortReference {
 
   @override
   void drivesLogic(Logic other) {
+    _connectOverlappingInterfacePortMaps();
+
     other <= portSubsetLogic;
   }
 
   @override
   void getsLogic(Logic other) {
+    _connectOverlappingInterfacePortMaps();
+
     var receiver = _externalPort;
     // we must look at the *port* for dimension analysis
     int? leafIndex;

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -371,6 +371,42 @@ class SlicePortReference extends PortReference {
 
   @override
   late final dynamic portSubset = _getPortSubset(port);
+
+  /// The flattened bit range covered by this slice or array element access.
+  @override
+  late final ({int lower, int upper}) _flatRange = _calculateFlatRange();
+
+  /// Calculates the flattened bit range for this reference from its array
+  /// indices and optional bit slice.
+  ({int lower, int upper}) _calculateFlatRange() {
+    var lower = 0;
+    var upper = port.width - 1;
+    var portElement = port;
+
+    if (dimensionAccess != null) {
+      for (final index in dimensionAccess!) {
+        final elementWidth = portElement.elements.first.width;
+        lower += index * elementWidth;
+        upper = lower + elementWidth - 1;
+
+        if (portElement is LogicArray) {
+          portElement = portElement.elements[index];
+        }
+      }
+    }
+
+    if (hasSlicing) {
+      final elementWidth = portElement.elements.first.width;
+      lower += sliceLowerIndex! * elementWidth;
+      upper =
+          lower + (sliceUpperIndex! - sliceLowerIndex! + 1) * elementWidth - 1;
+    }
+
+    return (lower: lower, upper: upper);
+  }
+
+  /// Returns the portion of [p] selected by this reference's array indices and
+  /// optional bit slice.
   dynamic _getPortSubset(Logic p) {
     var d = p;
 

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -90,6 +90,10 @@ class StandardPortReference extends PortReference {
   @override
   Logic get _internalPortSubset => _internalPort;
 
+  /// The full flattened bit range covered by an unsliced port reference.
+  @override
+  late final ({int lower, int upper}) _flatRange = (lower: 0, upper: width - 1);
+
   @override
   PortReference replicateTo(BridgeModule newModule, PortDirection direction,
       {String? newPortName}) {

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -113,11 +113,15 @@ class StandardPortReference extends PortReference {
 
   @override
   void drivesLogic(Logic other) {
+    _connectOverlappingInterfacePortMaps();
+
     other <= portSubset;
   }
 
   @override
   void getsLogic(Logic other) {
+    _connectOverlappingInterfacePortMaps();
+
     _externalPort <= other;
   }
 

--- a/test/hierarchy_connection_test.dart
+++ b/test/hierarchy_connection_test.dart
@@ -300,6 +300,161 @@ void main() {
     expect(mod2.port('apple').port.value, LogicValue.of('z1zz'));
   });
 
+  test('punchUpTo activates matching deferred interface port map', () async {
+    final leaf = BridgeModule('leaf')..addInput('request_i', null);
+    final intfRef = leaf.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'example',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = leaf.addPortMap(
+      leaf.port('request_i'),
+      intfRef.port('request'),
+    );
+    final top = BridgeModule('top')..addSubModule(leaf);
+
+    final topPortRef = intfRef.port('request').punchUpTo(top);
+
+    expect(portMap.isConnected, isTrue);
+
+    await top.build();
+
+    topPortRef.port.put(1);
+    expect(leaf.input('request_i').value, LogicValue.one);
+  });
+
+  test('punchUpTo activates deferred interface output port map', () async {
+    final leaf = BridgeModule('leaf')..addOutput('response_o');
+    final intfRef = leaf.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('response')]),
+      name: 'example',
+      role: PairRole.provider,
+      connect: false,
+    );
+    final portMap = leaf.addPortMap(
+      leaf.port('response_o'),
+      intfRef.port('response'),
+    );
+    final top = BridgeModule('top')..addSubModule(leaf);
+
+    final topPortRef = intfRef.port('response').punchUpTo(top);
+
+    expect(portMap.isConnected, isTrue);
+
+    await top.build();
+
+    leaf.output('response_o').put(1);
+    expect(topPortRef.port.value, LogicValue.one);
+  });
+
+  test('punchDownTo activates matching deferred interface port map', () async {
+    final top = BridgeModule('top')..addInput('request_i', null);
+    final leaf = BridgeModule('leaf');
+    top.addSubModule(leaf);
+    final intfRef = top.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'example',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = top.addPortMap(
+      top.port('request_i'),
+      intfRef.port('request'),
+    );
+
+    final leafPortRef = intfRef.port('request').punchDownTo(leaf);
+
+    expect(portMap.isConnected, isTrue);
+
+    await top.build();
+
+    top.input('request_i').put(1);
+    expect(leafPortRef.port.value, LogicValue.one);
+  });
+
+  test('punchDownTo activates deferred interface output port map', () async {
+    final top = BridgeModule('top')..addOutput('response_o');
+    final leaf = BridgeModule('leaf');
+    top.addSubModule(leaf);
+    final intfRef = top.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('response')]),
+      name: 'example',
+      role: PairRole.provider,
+      connect: false,
+    );
+    final portMap = top.addPortMap(
+      top.port('response_o'),
+      intfRef.port('response'),
+    );
+
+    final leafPortRef = intfRef.port('response').punchDownTo(leaf);
+
+    expect(portMap.isConnected, isTrue);
+
+    await top.build();
+
+    leafPortRef.port.put(1);
+    expect(top.output('response_o').value, LogicValue.one);
+  });
+
+  test('connectPorts activates matching deferred interface port map', () async {
+    final top = BridgeModule('top')..addInput('request_i', null);
+    final leaf = BridgeModule('leaf')..addInput('request_leaf_i', null);
+    top.addSubModule(leaf);
+    final intfRef = leaf.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'example',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = leaf.addPortMap(
+      leaf.port('request_leaf_i'),
+      intfRef.port('request'),
+    );
+
+    connectPorts(top.port('request_i'), intfRef.port('request'));
+
+    expect(portMap.isConnected, isTrue);
+
+    await top.build();
+
+    top.input('request_i').put(1);
+    expect(leaf.input('request_leaf_i').value, LogicValue.one);
+  });
+
+  test('gets activates deferred interface output port map', () async {
+    final top = BridgeModule('top');
+    final leaf = BridgeModule('leaf')..addOutput('response_o');
+    final sink = BridgeModule('sink')..addInput('response_i', null);
+    top
+      ..addSubModule(leaf)
+      ..addSubModule(sink);
+    final intfRef = leaf.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('response')]),
+      name: 'example',
+      role: PairRole.provider,
+      connect: false,
+    );
+    final portMap = leaf.addPortMap(
+      leaf.port('response_o'),
+      intfRef.port('response'),
+    );
+
+    sink.port('response_i').gets(intfRef.port('response'));
+
+    expect(portMap.isConnected, isTrue);
+
+    top
+      ..pullUpPort(leaf.createPort('dummy_leaf', PortDirection.input))
+      ..pullUpPort(sink.createPort('dummy_sink', PortDirection.input));
+
+    await top.build();
+
+    leaf.output('response_o').put(1);
+    expect(sink.input('response_i').value, LogicValue.one);
+  });
+
   test('hierarchy down to is itself for same module', () {
     final mod1 = BridgeModule('mod1');
     final hier = mod1.getHierarchyDownTo(mod1);

--- a/test/hierarchy_connection_test.dart
+++ b/test/hierarchy_connection_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // hierarchy_connection_test.dart

--- a/test/pretty_test.dart
+++ b/test/pretty_test.dart
@@ -85,13 +85,13 @@ west  west(.myInput(myInput));'''));
 
     expect(sv, contains('''
 aggregator  aggregator(.merged_bits(({
-merged_bits_subset[3], /* 3 */
-merged_bits_subset[2], /* 2 */
-merged_bits_subset[1], /* 1 */
-merged_bits_subset[0]  /* 0 */
+out_bit_1, /* 3 */
+out_bit_0, /* 2 */
+out_bit, /* 1 */
+out_bit_2  /* 0 */
 })),.clk(clk));
 '''));
-    expect(sv, contains('leaf1  leaf1(.out_bit(merged_bits_subset[1]));'));
+    expect(sv, contains('leaf1  leaf1(.out_bit(out_bit));'));
   });
 
   test('unconnected ports left unconnected', () async {

--- a/test/pretty_test.dart
+++ b/test/pretty_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pretty_test.dart

--- a/test/tie_off_test.dart
+++ b/test/tie_off_test.dart
@@ -83,7 +83,7 @@ void main() {
     expect(mod.output('banana').value, LogicValue.filled(8, LogicValue.zero));
   });
 
-  test('non-zero tieOffs preserve a shared readable constant in RTL', () async {
+  test('non-zero tieOffs preserve readable constants in RTL', () async {
     final mod = BridgeModule('mod')
       ..addOutput('apple', width: 8)
       ..addOutput('banana', width: 8);
@@ -94,9 +94,8 @@ void main() {
     await mod.build();
     final sv = mod.generateSynth();
 
-    expect(RegExp("8'h5a").allMatches(sv), hasLength(1));
-    expect(sv, contains('tieoff_const90'));
-    expect(sv, isNot(contains('tieoff_const90_0')));
+    expect(sv, contains("assign apple[7:0] = 8'h5a;"));
+    expect(sv, contains("assign banana[7:0] = 8'h5a;"));
     expect(mod.output('apple').value, LogicValue.ofInt(0x5a, 8));
     expect(mod.output('banana').value, LogicValue.ofInt(0x5a, 8));
   });

--- a/test/tie_off_test.dart
+++ b/test/tie_off_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // tie_off_test.dart

--- a/test/tie_off_test.dart
+++ b/test/tie_off_test.dart
@@ -159,4 +159,135 @@ void main() {
     expect(mod.interface('myIntf').port('fromProv').portSubsetLogic.value,
         LogicValue.filled(8, LogicValue.zero));
   });
+
+  test('tieOff activates matching deferred interface port map', () {
+    final mod = BridgeModule('mod')..addInput('request_i', null);
+    final intfRef = mod.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = mod.addPortMap(
+      mod.port('request_i'),
+      intfRef.port('request'),
+    );
+
+    intfRef.port('request').tieOff(value: 1);
+
+    expect(portMap.isConnected, isTrue);
+    expect(mod.input('request_i').value, LogicValue.one);
+  });
+
+  test('tieOffInterface activates matching deferred interface port map', () {
+    final mod = BridgeModule('mod')..addInput('request_i', null);
+    final intfRef = mod.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = mod.addPortMap(
+      mod.port('request_i'),
+      intfRef.port('request'),
+    );
+
+    mod.tieOffInterface(intfRef, value: 1);
+
+    expect(portMap.isConnected, isTrue);
+    expect(mod.input('request_i').value, LogicValue.one);
+  });
+
+  test('tieOff slice activates only overlapping deferred port maps', () {
+    final mod = BridgeModule('mod')
+      ..addInput('request_low_i', null, width: 4)
+      ..addInput('request_high_i', null, width: 4);
+    final intfRef = mod.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request', 8)]),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final lowPortMap = mod.addPortMap(
+      mod.port('request_low_i'),
+      intfRef.port('request[3:0]'),
+    );
+    final highPortMap = mod.addPortMap(
+      mod.port('request_high_i'),
+      intfRef.port('request[7:4]'),
+    );
+
+    intfRef.port('request[3:0]').tieOff(value: 0xa);
+
+    expect(lowPortMap.isConnected, isTrue);
+    expect(highPortMap.isConnected, isFalse);
+    expect(mod.input('request_low_i').value, LogicValue.ofInt(0xa, 4));
+    expect(
+        mod.input('request_high_i').value, LogicValue.filled(4, LogicValue.z));
+  });
+
+  test('tieOff 3d array element activates only overlapping port maps', () {
+    final mod = BridgeModule('mod')
+      ..addInput('request_101_i', null, width: 4)
+      ..addInput('request_110_i', null, width: 4);
+    final intfRef = mod.addInterface(
+      PairInterface(
+        portsFromProvider: [
+          LogicArray.port('request', [2, 2, 2], 4)
+        ],
+      ),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final request101PortMap = mod.addPortMap(
+      mod.port('request_101_i'),
+      intfRef.port('request[1][0][1]'),
+    );
+    final request110PortMap = mod.addPortMap(
+      mod.port('request_110_i'),
+      intfRef.port('request[1][1][0]'),
+    );
+
+    intfRef.port('request[1][0][1]').tieOff(value: 0xc);
+
+    expect(request101PortMap.isConnected, isTrue);
+    expect(request110PortMap.isConnected, isFalse);
+    expect(mod.input('request_101_i').value, LogicValue.ofInt(0xc, 4));
+    expect(
+        mod.input('request_110_i').value, LogicValue.filled(4, LogicValue.z));
+  });
+
+  test('tieOff full 3d array activates overlapping deferred port maps', () {
+    final mod = BridgeModule('mod')
+      ..addInput('request_000_i', null, width: 4)
+      ..addInput('request_111_i', null, width: 4);
+    final intfRef = mod.addInterface(
+      PairInterface(
+        portsFromProvider: [
+          LogicArray.port('request', [2, 2, 2], 4)
+        ],
+      ),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final request000PortMap = mod.addPortMap(
+      mod.port('request_000_i'),
+      intfRef.port('request[0][0][0]'),
+    );
+    final request111PortMap = mod.addPortMap(
+      mod.port('request_111_i'),
+      intfRef.port('request[1][1][1]'),
+    );
+
+    intfRef.port('request').tieOff(value: 1, fill: true);
+
+    expect(request000PortMap.isConnected, isTrue);
+    expect(request111PortMap.isConnected, isTrue);
+    expect(
+        mod.input('request_000_i').value, LogicValue.filled(4, LogicValue.one));
+    expect(
+        mod.input('request_111_i').value, LogicValue.filled(4, LogicValue.one));
+  });
 }

--- a/test/tie_off_test.dart
+++ b/test/tie_off_test.dart
@@ -179,6 +179,47 @@ void main() {
     expect(mod.input('request_i').value, LogicValue.one);
   });
 
+  test('getsLogic activates matching deferred interface port map', () {
+    final mod = BridgeModule('mod')..addInput('request_i', null);
+    final intfRef = mod.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('request')]),
+      name: 'myIntf',
+      role: PairRole.consumer,
+      connect: false,
+    );
+    final portMap = mod.addPortMap(
+      mod.port('request_i'),
+      intfRef.port('request'),
+    );
+
+    intfRef.port('request').getsLogic(Const(1));
+
+    expect(portMap.isConnected, isTrue);
+    expect(mod.input('request_i').value, LogicValue.one);
+  });
+
+  test('drivesLogic activates matching deferred interface port map', () {
+    final mod = BridgeModule('mod')..addOutput('response_o');
+    final intfRef = mod.addInterface(
+      PairInterface(portsFromProvider: [Logic.port('response')]),
+      name: 'myIntf',
+      role: PairRole.provider,
+      connect: false,
+    );
+    final portMap = mod.addPortMap(
+      mod.port('response_o'),
+      intfRef.port('response'),
+    );
+    final probe = Logic(name: 'probe');
+
+    intfRef.port('response').drivesLogic(probe);
+
+    expect(portMap.isConnected, isTrue);
+
+    mod.output('response_o').put(1);
+    expect(probe.value, LogicValue.one);
+  });
+
   test('tieOffInterface activates matching deferred interface port map', () {
     final mod = BridgeModule('mod')..addInput('request_i', null);
     final intfRef = mod.addInterface(


### PR DESCRIPTION
## Description & Motivation

Fixes the reported `tieOff` bug where calling `tieOff` on a mapped `InterfacePortReference` drove only the logical interface signal and left deferred `PortMap`s unresolved. The fix now activates deferred port maps whose logical interface port overlaps the operated-on port or slice before treating a mapped interface port as a concrete port operation endpoint.

While auditing the same category of behavior, this also fixes related mapped interface port operations that could bypass deferred maps: direct `connectPorts`/`gets`, `punchUpTo`, `punchDownTo`, `getsLogic`, and `drivesLogic`. This keeps the behavior consistent for port-level operations inherited by `InterfacePortReference`.

The overlap check uses cached flattened ranges on `PortReference`s so full ports, scalar slices, array elements, and multi-dimensional array accesses can be compared consistently while keeping slice-specific flattening logic in `SlicePortReference`.

## Related Issue(s)

Fix #49

## Testing

- `dart analyze lib/src/references/port_reference.dart lib/src/references/standard_port_reference.dart lib/src/references/slice_port_reference.dart lib/src/references/interface_port_reference.dart test/tie_off_test.dart test/hierarchy_connection_test.dart`
- `dart test test/tie_off_test.dart test/hierarchy_connection_test.dart`
- `dart test`

Added regression coverage for:
- Direct `tieOff` on a deferred mapped interface port
- `tieOffInterface` on a deferred mapped interface port
- Direct `getsLogic` and `drivesLogic` on deferred mapped interface ports
- `connectPorts` with a deferred mapped interface port endpoint
- `gets` with a deferred mapped interface output as the driver
- `punchUpTo` and `punchDownTo` with deferred mapped interface input and output endpoints
- Scalar slice tie-off activating only overlapping maps
- 3D array element tie-off activating only overlapping maps
- Full 3D array tie-off activating overlapping deep element maps

## Backwards-compatibility

No breaking change expected. This resolves deferred mappings before existing port-level operations proceed, so mapped interface ports behave more like the physical `PortReference`s they represent.

## Documentation

No external documentation updates required. Private helper doc comments were added for the overlap, flattened-range, and mapped-port activation logic.