### PR TITLE
Add typed port and interface reference APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next release
+
+- Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped`.
+- Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup.
+- Added type-preserving interface hierarchy APIs: `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped`. These APIs intentionally omit port exclusions because a partial interface cannot retain its concrete type.
+
 ## 0.2.3
 
 - Added `SameModuleConnectionType` enum to disambiguate same-module connections involving `inOut` ports. When connecting two ports on the same module where at least one is `inOut` and neither is `input`, a `SameModuleConnectionType` (`loopback` or `passthrough`) must now be provided to `gets()` or `connectPorts()` to specify whether the connection should use external-facing or internal-facing ports. (<https://github.com/intel/rohd-bridge/pull/39>). This change is backwards compatible except for ambiguous scenarios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-- Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped`.
-- Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup.
-- Added type-preserving interface hierarchy APIs: `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped`. These APIs intentionally omit port exclusions because a partial interface cannot retain its concrete type.
+- Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
+- Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).
+- Added type-preserving interface hierarchy APIs: `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped`. These APIs intentionally omit port exclusions because a partial interface cannot retain its concrete type (<https://github.com/intel/rohd-bridge/pull/58>).
 
 ## 0.2.3
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ final myIntf = myMod.interface('my_interface');
 myIntf.port('intf_port_a[8:3]');
 ```
 
-Typed lookup APIs preserve concrete ROHD port and interface types when they are
-known:
+Typed lookup APIs preserve concrete ROHD port and interface types when they are known:
 
 ```dart
 final TypedPortReference<LogicArray> arrayPort =
@@ -216,13 +215,7 @@ final InterfaceReference<MyIntf> topIntf =
     topMod.pullUpTypedInterface(myTypedIntf);
 ```
 
-`tryPort`, `tryTypedPort`, `tryInterface`, and `tryTypedInterface` provide
-nullable lookup variants. A `TypedPortReference` can be passed directly to APIs
-that accept `PortReference`. Slicing or indexing a typed port returns an
-untyped `PortReference` because the selected shape may differ from the root
-port type. Typed interface punching and pull-up APIs omit `exceptPorts` because
-removing ports changes the concrete interface type; use the existing untyped
-APIs when exclusions are needed.
+`tryPort`, `tryTypedPort`, `tryInterface`, and `tryTypedInterface` provide nullable lookup variants. A `TypedPortReference` can be passed directly to APIs that accept `PortReference`. Slicing or indexing a typed port returns an untyped `PortReference` because the selected shape may differ from the root port type. Typed interface punching and pull-up APIs omit `exceptPorts` because removing ports changes the concrete interface type; use the existing untyped APIs when exclusions are needed.
 
 You can also do things like `slice` or index off a `PortReference`, similar to how you can in ROHD for normal `Logic`s.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,27 @@ final myIntf = myMod.interface('my_interface');
 myIntf.port('intf_port_a[8:3]');
 ```
 
+Typed lookup APIs preserve concrete ROHD port and interface types when they are
+known:
+
+```dart
+final TypedPortReference<LogicArray> arrayPort =
+    myMod.typedPort<LogicArray>('arr_port_b');
+final InterfaceReference<MyIntf> myTypedIntf =
+    myMod.typedInterface<MyIntf>('my_interface');
+
+final InterfaceReference<MyIntf> topIntf =
+    topMod.pullUpTypedInterface(myTypedIntf);
+```
+
+`tryPort`, `tryTypedPort`, `tryInterface`, and `tryTypedInterface` provide
+nullable lookup variants. A `TypedPortReference` can be passed directly to APIs
+that accept `PortReference`. Slicing or indexing a typed port returns an
+untyped `PortReference` because the selected shape may differ from the root
+port type. Typed interface punching and pull-up APIs omit `exceptPorts` because
+removing ports changes the concrete interface type; use the existing untyped
+APIs when exclusions are needed.
+
 You can also do things like `slice` or index off a `PortReference`, similar to how you can in ROHD for normal `Logic`s.
 
 #### Making Connections

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -506,8 +506,43 @@ class BridgeModule extends Module with SystemVerilog {
   ///
   /// Throws an [Exception] if no interface with the given [name] exists.
   InterfaceReference interface(String name) =>
-      interfaces[name] ??
+      tryInterface(name) ??
       (throw RohdBridgeException('Interface $name not found on $this'));
+
+  /// Tries to get a reference to an interface by [name].
+  ///
+  /// Returns `null` if no interface with the given [name] exists.
+  InterfaceReference? tryInterface(String name) => interfaces[name];
+
+  /// Tries to get an interface named [name] with concrete type [InterfaceType].
+  ///
+  /// Returns `null` if the interface does not exist or is not an
+  /// [InterfaceType].
+  InterfaceReference<InterfaceType>?
+      tryTypedInterface<InterfaceType extends PairInterface>(String name) {
+    final interfaceReference = tryInterface(name);
+
+    return interfaceReference is InterfaceReference<InterfaceType>
+        ? interfaceReference
+        : null;
+  }
+
+  /// Gets an interface named [name] with concrete type [InterfaceType].
+  ///
+  /// Throws a [RohdBridgeException] if the interface does not exist or is not
+  /// an [InterfaceType].
+  InterfaceReference<InterfaceType>
+      typedInterface<InterfaceType extends PairInterface>(String name) {
+    final interfaceReference = interface(name);
+
+    if (interfaceReference is! InterfaceReference<InterfaceType>) {
+      throw RohdBridgeException('Interface $name on $this is a '
+          '${interfaceReference.interface.runtimeType}, not an '
+          '$InterfaceType.');
+    }
+
+    return interfaceReference;
+  }
 
   /// Creates a hierarchical connection by pulling an interface up from a
   /// submodule.
@@ -537,6 +572,34 @@ class BridgeModule extends Module with SystemVerilog {
           allowIntfUniquification: allowIntfUniquification,
           exceptPorts: exceptPorts,
           portUniquify: portUniquify);
+
+  /// Pulls [subModuleIntf] up while preserving [InterfaceType].
+  ///
+  /// This delegates hierarchy traversal and connection behavior to
+  /// [pullUpInterface]. Port exclusions are intentionally unavailable because
+  /// removing ports changes the concrete interface type.
+  InterfaceReference<InterfaceType>
+      pullUpTypedInterface<InterfaceType extends PairInterface>(
+    InterfaceReference<InterfaceType> subModuleIntf, {
+    String? newIntfName,
+    bool allowIntfUniquification = true,
+    String Function(String logical, String physical)? portUniquify,
+  }) {
+    final pulledUpInterface = pullUpInterface(
+      subModuleIntf,
+      newIntfName: newIntfName,
+      allowIntfUniquification: allowIntfUniquification,
+      portUniquify: portUniquify,
+    );
+
+    if (pulledUpInterface is! InterfaceReference<InterfaceType>) {
+      throw RohdBridgeException(
+          'Pulling up ${subModuleIntf.name} did not preserve '
+          '$InterfaceType.');
+    }
+
+    return pulledUpInterface;
+  }
 
   /// Performs the funcitonality of [pullUpInterface], but also connects the
   /// top-level returned interface to [topToConnect].
@@ -746,6 +809,14 @@ class BridgeModule extends Module with SystemVerilog {
     return PortReference.fromString(this, portRefString);
   }
 
+  /// Tries to create a typed port reference from [portRefString].
+  ///
+  /// Returns `null` if the port does not exist or its root port is not a
+  /// [PortType]. Parsing and name resolution are delegated to [tryPort].
+  TypedPortReference<PortType>? tryTypedPort<PortType extends Logic>(
+          String portRefString) =>
+      tryPort(portRefString)?.tryAsTyped<PortType>();
+
   /// Creates a port reference from a string representation with advanced
   /// parsing.
   ///
@@ -767,6 +838,15 @@ class BridgeModule extends Module with SystemVerilog {
   PortReference port(String portRefString) =>
       tryPort(portRefString) ??
       (throw RohdBridgeException('Port $portRefString not found in $name'));
+
+  /// Creates a typed port reference from [portRefString].
+  ///
+  /// Throws a [RohdBridgeException] if the port does not exist or its root
+  /// port is not a [PortType]. Parsing and name resolution are delegated to
+  /// [port].
+  TypedPortReference<PortType> typedPort<PortType extends Logic>(
+          String portRefString) =>
+      port(portRefString).asTyped<PortType>();
 
   /// Internal tracking map for hierarchical port connectivity optimization.
   ///

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -225,6 +225,15 @@ class InterfaceReference<InterfaceType extends PairInterface>
     throw RohdBridgeException('Invalid port access string: $portRef');
   }
 
+  /// Tries to get a typed reference to [portRef] within this interface.
+  ///
+  /// Returns `null` if the port does not exist or its root port is not a
+  /// [PortType]. Parsing and interface-port behavior are delegated to
+  /// [tryPort].
+  TypedPortReference<PortType>? tryTypedPort<PortType extends Logic>(
+          String portRef) =>
+      tryPort(portRef)?.tryAsTyped<PortType>();
+
   /// Gets a reference to a specific port within this interface.
   ///
   /// The [portRef] can be either a simple port name (e.g., "data") or include
@@ -235,6 +244,15 @@ class InterfaceReference<InterfaceType extends PairInterface>
   InterfacePortReference port(String portRef) =>
       tryPort(portRef) ??
       (throw RohdBridgeException('Port $portRef not found on $this'));
+
+  /// Gets a typed reference to [portRef] within this interface.
+  ///
+  /// Throws a [RohdBridgeException] if the port does not exist or its root
+  /// port is not a [PortType]. Parsing and interface-port behavior are
+  /// delegated to [port].
+  TypedPortReference<PortType> typedPort<PortType extends Logic>(
+          String portRef) =>
+      port(portRef).asTyped<PortType>();
 
   /// Creates a copy of this interface in a parent module.
   ///
@@ -260,6 +278,53 @@ class InterfaceReference<InterfaceType extends PairInterface>
     Set<String>? exceptPorts,
     String Function(String logical)? portUniquify,
   }) {
+    if (exceptPorts == null || exceptPorts.isEmpty) {
+      return punchUpToTyped(
+        newModule,
+        newIntfName: newIntfName,
+        allowNameUniquification: allowNameUniquification,
+        portUniquify: portUniquify,
+      );
+    }
+
+    return _punchUpTo(
+      newModule,
+      interface._cloneExcept(exceptPorts: exceptPorts),
+      newIntfName: newIntfName,
+      allowNameUniquification: allowNameUniquification,
+      exceptPorts: exceptPorts,
+      portUniquify: portUniquify,
+    );
+  }
+
+  /// Creates a type-preserving copy of this interface in a parent module.
+  ///
+  /// Unlike [punchUpTo], this method does not accept port exclusions because
+  /// removing ports changes the concrete interface type.
+  InterfaceReference<InterfaceType> punchUpToTyped(
+    BridgeModule newModule, {
+    String? newIntfName,
+    bool allowNameUniquification = false,
+    String Function(String logical)? portUniquify,
+  }) =>
+      _punchUpTo(
+        newModule,
+        interface.clone() as InterfaceType,
+        newIntfName: newIntfName,
+        allowNameUniquification: allowNameUniquification,
+        exceptPorts: null,
+        portUniquify: portUniquify,
+      );
+
+  InterfaceReference<NewInterfaceType>
+      _punchUpTo<NewInterfaceType extends PairInterface>(
+    BridgeModule newModule,
+    NewInterfaceType clonedInterface, {
+    required String? newIntfName,
+    required bool allowNameUniquification,
+    required Set<String>? exceptPorts,
+    required String Function(String logical)? portUniquify,
+  }) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (module.parent != newModule) {
       throw RohdBridgeException(
@@ -269,7 +334,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
     _connectAllPortMaps(exceptPorts: exceptPorts);
 
     final newRef = newModule.addInterface(
-      interface._cloneExcept(exceptPorts: exceptPorts),
+      clonedInterface,
       name: newIntfName ?? name,
       role: role,
       allowNameUniquification: allowNameUniquification,
@@ -408,6 +473,53 @@ class InterfaceReference<InterfaceType extends PairInterface>
     Set<String>? exceptPorts,
     String Function(String logical)? portUniquify,
   }) {
+    if (exceptPorts == null || exceptPorts.isEmpty) {
+      return punchDownToTyped(
+        subModule,
+        newIntfName: newIntfName,
+        allowNameUniquification: allowNameUniquification,
+        portUniquify: portUniquify,
+      );
+    }
+
+    return _punchDownTo(
+      subModule,
+      interface._cloneExcept(exceptPorts: exceptPorts),
+      newIntfName: newIntfName,
+      allowNameUniquification: allowNameUniquification,
+      exceptPorts: exceptPorts,
+      portUniquify: portUniquify,
+    );
+  }
+
+  /// Creates a type-preserving copy of this interface in a submodule.
+  ///
+  /// Unlike [punchDownTo], this method does not accept port exclusions because
+  /// removing ports changes the concrete interface type.
+  InterfaceReference<InterfaceType> punchDownToTyped(
+    BridgeModule subModule, {
+    String? newIntfName,
+    bool allowNameUniquification = false,
+    String Function(String logical)? portUniquify,
+  }) =>
+      _punchDownTo(
+        subModule,
+        interface.clone() as InterfaceType,
+        newIntfName: newIntfName,
+        allowNameUniquification: allowNameUniquification,
+        exceptPorts: null,
+        portUniquify: portUniquify,
+      );
+
+  InterfaceReference<NewInterfaceType>
+      _punchDownTo<NewInterfaceType extends PairInterface>(
+    BridgeModule subModule,
+    NewInterfaceType clonedInterface, {
+    required String? newIntfName,
+    required bool allowNameUniquification,
+    required Set<String>? exceptPorts,
+    required String Function(String logical)? portUniquify,
+  }) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (subModule.parent != module) {
       throw RohdBridgeException(
@@ -417,7 +529,7 @@ class InterfaceReference<InterfaceType extends PairInterface>
     _connectAllPortMaps(exceptPorts: exceptPorts);
 
     final newRef = subModule.addInterface(
-      interface._cloneExcept(exceptPorts: exceptPorts),
+      clonedInterface,
       name: newIntfName ?? name,
       role: role,
       allowNameUniquification: allowNameUniquification,

--- a/lib/src/references/references.dart
+++ b/lib/src/references/references.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:collection/collection.dart';
@@ -8,6 +8,7 @@ import 'package:rohd_bridge/rohd_bridge.dart';
 import 'package:rohd_bridge/src/references/reference.dart';
 
 part 'port_reference.dart';
+part 'typed_port_reference.dart';
 part 'interface_reference.dart';
 part 'slice_port_reference.dart';
 part 'standard_port_reference.dart';

--- a/lib/src/references/typed_port_reference.dart
+++ b/lib/src/references/typed_port_reference.dart
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// typed_port_reference.dart
+// Definitions for typed access to port references.
+//
+// 2026 August 12
+// Author: Max Korbel <max.korbel@intel.com>
+
+part of 'references.dart';
+
+/// A typed view of a [PortReference].
+///
+/// [PortType] is the concrete type of the root [port]. It does not describe
+/// [portSubset], whose type can change based on slicing and array indexing.
+///
+/// This extension type implements [PortReference], so it can be passed directly
+/// to existing APIs that accept an untyped reference without allocation or
+/// conversion.
+extension type TypedPortReference<PortType extends Logic>._(
+    PortReference _reference) implements PortReference {
+  /// Creates a typed view of [reference].
+  ///
+  /// Throws a [RohdBridgeException] if the referenced port is not a [PortType].
+  factory TypedPortReference(PortReference reference) {
+    if (reference.port is! PortType) {
+      throw RohdBridgeException('Port $reference on ${reference.module} is a '
+          '${reference.port.runtimeType}, not a $PortType.');
+    }
+
+    return TypedPortReference<PortType>._(reference);
+  }
+
+  /// The root port with its checked concrete type.
+  @redeclare
+  PortType get port => _reference.port as PortType;
+}
+
+/// Checked typed views for [PortReference]s.
+extension TypedPortReferenceConversions on PortReference {
+  /// Returns this reference as a [TypedPortReference] when its root port is a
+  /// [PortType].
+  ///
+  /// Throws a [RohdBridgeException] if the referenced port is not a [PortType].
+  TypedPortReference<PortType> asTyped<PortType extends Logic>() =>
+      TypedPortReference<PortType>(this);
+
+  /// Returns this reference as a [TypedPortReference], or `null` if its root
+  /// port is not a [PortType].
+  TypedPortReference<PortType>? tryAsTyped<PortType extends Logic>() =>
+      port is PortType ? TypedPortReference<PortType>._(this) : null;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/intel/rohd-bridge/issues
 documentation: https://intel.github.io/rohd-bridge/rohd_bridge/rohd_bridge-library.html
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/test/typed_reference_test.dart
+++ b/test/typed_reference_test.dart
@@ -1,0 +1,268 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// typed_reference_test.dart
+// Tests for typed reference APIs.
+//
+// 2026 August 12
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+class TestPairInterface extends PairInterface {
+  TestPairInterface()
+      : super(
+          portsFromProvider: [Logic.port('response', 8)],
+          portsFromConsumer: [Logic.port('request', 8)],
+        );
+
+  @override
+  TestPairInterface clone() => TestPairInterface();
+}
+
+class OtherPairInterface extends PairInterface {
+  OtherPairInterface() : super(portsFromProvider: [Logic.port('other', 8)]);
+
+  @override
+  OtherPairInterface clone() => OtherPairInterface();
+}
+
+class TestLogicStructure extends LogicStructure {
+  final Logic header;
+  final Logic payload;
+
+  factory TestLogicStructure({String name = 'testLogicStructure'}) =>
+      TestLogicStructure._(
+        Logic(name: 'header', width: 2),
+        Logic(name: 'payload', width: 6),
+        name: name,
+      );
+
+  TestLogicStructure._(
+    this.header,
+    this.payload, {
+    required String name,
+  }) : super([header, payload], name: name);
+
+  @override
+  TestLogicStructure clone({String? name}) =>
+      TestLogicStructure(name: name ?? this.name);
+}
+
+T _expectType<T>(T value) => value;
+
+BridgeModule _module(String name) =>
+    BridgeModule(name, reserveDefinitionName: false);
+
+void main() {
+  group('typed ports', () {
+    test('checks and exposes the root port type', () {
+      final module = _module('module')
+        ..addInput('data', null, width: 8)
+        ..addInputArray(
+          'array',
+          null,
+          dimensions: [2],
+          elementWidth: 4,
+        );
+
+      final data = _expectType<TypedPortReference<Logic>>(
+        module.typedPort('data'),
+      );
+      final dataPort = _expectType<Logic>(data.port);
+      expect(dataPort.width, 8);
+
+      final array = _expectType<TypedPortReference<LogicArray>>(
+        module.typedPort('array'),
+      );
+      final arrayPort = _expectType<LogicArray>(array.port);
+      expect(arrayPort.dimensions, [2]);
+
+      expect(module.tryTypedPort<LogicArray>('data'), isNull);
+      expect(
+        () => module.typedPort<LogicArray>('data'),
+        throwsA(isA<RohdBridgeException>()),
+      );
+    });
+
+    test('preserves a custom LogicStructure type', () {
+      final module = _module('module')
+        ..addTypedInput('structured', TestLogicStructure());
+
+      final structured = _expectType<TypedPortReference<TestLogicStructure>>(
+        module.typedPort('structured'),
+      );
+      final structuredPort = _expectType<TestLogicStructure>(structured.port);
+
+      expect(structuredPort.header.width, 2);
+      expect(structuredPort.payload.width, 6);
+      expect(module.tryTypedPort<LogicArray>('structured'), isNull);
+    });
+
+    test('is transparent to existing PortReference APIs', () {
+      final producer = _module('producer')..addOutput('data', width: 8);
+      final consumer = _module('consumer')..addInput('data', null, width: 8);
+      final top = _module('top')
+        ..addSubModule(producer)
+        ..addSubModule(consumer);
+
+      final driver = _expectType<TypedPortReference<Logic>>(
+        producer.typedPort('data'),
+      );
+      final receiver = _expectType<TypedPortReference<Logic>>(
+        consumer.typedPort('data'),
+      );
+      final untypedDriver = _expectType<PortReference>(driver);
+
+      expect(untypedDriver, producer.port('data'));
+      connectPorts(driver, receiver);
+      expect(top.subBridgeModules, containsAll([producer, consumer]));
+    });
+
+    test('widens slices to PortReference', () {
+      final module = _module('module')
+        ..addInputArray(
+          'array',
+          null,
+          dimensions: [2],
+          elementWidth: 4,
+        );
+      final array = _expectType<TypedPortReference<LogicArray>>(
+        module.typedPort('array'),
+      );
+
+      final element = _expectType<PortReference>(array[0]);
+
+      expect(element.portSubset, isA<Logic>());
+      expect(element.width, 4);
+    });
+
+    test('supports typed interface port lookup', () {
+      final module = _module('module')
+        ..addInterface(
+          TestPairInterface(),
+          name: 'bus',
+          role: PairRole.provider,
+        );
+      final interfaceReference =
+          module.typedInterface<TestPairInterface>('bus');
+
+      final response = _expectType<TypedPortReference<Logic>>(
+        interfaceReference.typedPort('response'),
+      );
+
+      expect(response.port.width, 8);
+      expect(interfaceReference.tryTypedPort<LogicArray>('response'), isNull);
+    });
+  });
+
+  group('typed interfaces', () {
+    test('supports nullable and checked lookup', () {
+      final module = _module('module');
+      final added = module.addInterface(
+        TestPairInterface(),
+        name: 'bus',
+        role: PairRole.provider,
+      );
+
+      final found = _expectType<InterfaceReference<TestPairInterface>>(
+        module.typedInterface('bus'),
+      );
+
+      expect(found, added);
+      expect(module.tryInterface('bus'), added);
+      expect(module.tryInterface('missing'), isNull);
+      expect(module.tryTypedInterface<TestPairInterface>('bus'), added);
+      expect(module.tryTypedInterface<OtherPairInterface>('bus'), isNull);
+      expect(
+        () => module.typedInterface<OtherPairInterface>('bus'),
+        throwsA(isA<RohdBridgeException>()),
+      );
+    });
+
+    test('punches up while preserving the interface type', () async {
+      final leaf = _module('leaf');
+      final leafInterface = leaf.addInterface(
+        TestPairInterface(),
+        name: 'bus',
+        role: PairRole.provider,
+      );
+      final top = _module('top')..addSubModule(leaf);
+
+      final topInterface = _expectType<InterfaceReference<TestPairInterface>>(
+        leafInterface.punchUpToTyped(top),
+      );
+
+      expect(topInterface.interface, isA<TestPairInterface>());
+      expect(topInterface.internalInterface, isA<TestPairInterface>());
+      expect(top.typedInterface<TestPairInterface>('bus'), topInterface);
+
+      await top.build();
+    });
+
+    test('punches down while preserving the interface type', () async {
+      final top = _module('top');
+      final topInterface = top.addInterface(
+        TestPairInterface(),
+        name: 'bus',
+        role: PairRole.provider,
+      );
+      final leaf = _module('leaf');
+      top.addSubModule(leaf);
+
+      final leafInterface = _expectType<InterfaceReference<TestPairInterface>>(
+        topInterface.punchDownToTyped(leaf),
+      );
+
+      expect(leafInterface.interface, isA<TestPairInterface>());
+      expect(leafInterface.internalInterface, isA<TestPairInterface>());
+      expect(leaf.typedInterface<TestPairInterface>('bus'), leafInterface);
+
+      await top.build();
+    });
+
+    test('pulls up through multiple levels with its type', () async {
+      final leaf = _module('leaf');
+      final leafInterface = leaf.addInterface(
+        TestPairInterface(),
+        name: 'bus',
+        role: PairRole.consumer,
+      );
+      final middle = _module('middle')..addSubModule(leaf);
+      final top = _module('top')..addSubModule(middle);
+
+      final topInterface = _expectType<InterfaceReference<TestPairInterface>>(
+        top.pullUpTypedInterface(leafInterface),
+      );
+
+      expect(topInterface.interface, isA<TestPairInterface>());
+      expect(
+        middle.typedInterface<TestPairInterface>('bus').interface,
+        isA<TestPairInterface>(),
+      );
+
+      await top.build();
+    });
+
+    test('legacy exclusions produce an untyped partial interface', () {
+      final leaf = _module('leaf');
+      final leafInterface = leaf.addInterface(
+        TestPairInterface(),
+        name: 'bus',
+        role: PairRole.provider,
+      );
+      final top = _module('top')..addSubModule(leaf);
+
+      final partial = leafInterface.punchUpTo(
+        top,
+        exceptPorts: {'request'},
+      );
+
+      expect(partial.interface, isA<PairInterface>());
+      expect(partial.interface, isNot(isA<TestPairInterface>()));
+      expect(top.tryTypedInterface<TestPairInterface>('bus'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description & Motivation

Adds type-preserving APIs for working with ROHD Bridge ports and interfaces while reusing the existing reference and connection implementations.

`TypedPortReference<T>` provides a zero-allocation typed view over `PortReference`, including checked `asTyped`, `tryAsTyped`, `typedPort`, and `tryTypedPort` APIs. It supports concrete `Logic` subtypes such as `LogicArray` and custom `LogicStructure` classes. Slicing and indexing widen back to `PortReference` because the selected shape may differ from the root port type.

Adds `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup. Adds `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped` for preserving concrete `PairInterface` types through hierarchy operations.

The typed hierarchy APIs intentionally omit `exceptPorts` because removing ports produces a partial `PairInterface` that cannot retain the original concrete interface type. Existing untyped APIs continue to support exclusions.

The legacy and typed hierarchy APIs share generic private helpers so validation, cloning, port mapping, and connection behavior remain centralized.

## Related Issue(s)

None.

## Testing

Ran `tool/run_checks.sh`, including dependency resolution, formatting verification, static analysis, API documentation generation, all 2,597 tests, and temporary-file checks. All checks passed.

Added focused tests for typed scalar and array ports, custom `LogicStructure` ports, transparent `PortReference` interoperability, slice widening, typed interface-port lookup, nullable and checked interface lookup, typed punch-up and punch-down, multilevel typed pull-up, and legacy interface exclusions.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

The new APIs are additive, and all existing public APIs and exclusion behavior remain available. The minimum supported Dart SDK increases from 3.0 to 3.3 because `TypedPortReference` uses extension types; consumers on Dart 3.0 through 3.2 must remain on an earlier package release.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes. The README documents typed port and interface lookup, typed hierarchy operations, slice widening, and the `exceptPorts` limitation. The changelog includes the APIs under `Next release`, and public API documentation is included in the source comments.