### PR TITLE
Support same-module connection types in connectInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module.
+- Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added type-preserving interface hierarchy APIs: `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped`. These APIs intentionally omit port exclusions because a partial interface cannot retain its concrete type (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module.
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added type-preserving interface hierarchy APIs: `pullUpTypedInterface`, `punchUpToTyped`, and `punchDownToTyped`. These APIs intentionally omit port exclusions because a partial interface cannot retain its concrete type (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1439,6 +1439,12 @@ void connectPorts(
 /// Uniquification also respects [BridgeModule.allowUniquification] at each
 /// level. The [exceptPorts] parameter is an optional set of strings
 /// representing the logical port names to be excluded.
+///
+/// When [intf1] and [intf2] are on the same module,
+/// [sameModuleConnectionType] selects whether their external-facing
+/// ([SameModuleConnectionType.loopback]) or internal-facing
+/// ([SameModuleConnectionType.passthrough]) interfaces are connected. If it is
+/// omitted, loopback behavior is used for backwards compatibility.
 void connectInterfaces(
   InterfaceReference intf1,
   InterfaceReference intf2, {
@@ -1446,6 +1452,7 @@ void connectInterfaces(
   String? intf2PathNewName,
   bool allowIntf1PathUniquification = true,
   bool allowIntf2PathUniquification = true,
+  SameModuleConnectionType? sameModuleConnectionType,
   Set<String>? exceptPorts,
   // TODO(mkorbel): finish these,
   //  possibly wont be needed for connectInterfaces
@@ -1458,6 +1465,13 @@ void connectInterfaces(
 
   final intf1Instance = intf1.module;
   final intf2Instance = intf2.module;
+
+  if (sameModuleConnectionType != null && intf1Instance != intf2Instance) {
+    throw RohdBridgeException(
+        'SameModuleConnectionType should only be provided when connecting '
+        'interfaces on the same module, but $intf1 is on $intf1Instance and '
+        '$intf2 is on $intf2Instance.');
+  }
 
   if (intf1.role != intf2.role) {
     // up and down case
@@ -1512,7 +1526,11 @@ void connectInterfaces(
       exceptPorts: exceptPorts,
     );
 
-    intf1Top.connectTo(intf2Top, exceptPorts: exceptPorts);
+    intf1Top.connectTo(
+      intf2Top,
+      sameModuleConnectionType: sameModuleConnectionType,
+      exceptPorts: exceptPorts,
+    );
   } else if (intf1.role == intf2.role) {
     final intf1ToIntf2Path = intf1Instance.getHierarchyDownTo(intf2Instance);
     final intf2ToIntf1Path = intf2Instance.getHierarchyDownTo(intf1Instance);

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1473,6 +1473,15 @@ void connectInterfaces(
         '$intf2 is on $intf2Instance.');
   }
 
+  if (intf1Instance == intf2Instance) {
+    intf1.connectTo(
+      intf2,
+      sameModuleConnectionType: sameModuleConnectionType,
+      exceptPorts: exceptPorts,
+    );
+    return;
+  }
+
   if (intf1.role != intf2.role) {
     // up and down case
     final commonParent = findCommonParent(intf1Instance, intf2Instance);

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -418,12 +418,28 @@ class InterfaceReference<InterfaceType extends PairInterface>
   /// connection. When ports are excluded, individual port connections are made
   /// rather than using bulk interface connection methods.
   ///
+  /// When both interfaces are on the same module, [sameModuleConnectionType]
+  /// selects whether the external-facing interfaces are connected for a
+  /// loopback or the internal-facing interfaces are connected for a
+  /// passthrough. It must not be provided for interfaces on different modules.
+  ///
   /// Throws an exception if both interfaces have the same role.
-  void connectTo(InterfaceReference other, {Set<String>? exceptPorts}) {
+  void connectTo(
+    InterfaceReference other, {
+    SameModuleConnectionType? sameModuleConnectionType,
+    Set<String>? exceptPorts,
+  }) {
     // TODO(mkorbel1): remove restriction that it must be adjacent (https://github.com/intel/rohd-bridge/issues/13)
     if (other.module.parent != module.parent) {
       throw RohdBridgeException('Both interfaces must be on modules that share'
           ' the same parent module.');
+    }
+
+    if (sameModuleConnectionType != null && other.module != module) {
+      throw RohdBridgeException(
+          'SameModuleConnectionType should only be provided when connecting '
+          'interfaces on the same module, but $this is on $module and $other '
+          'is on ${other.module}.');
     }
 
     if (other.role == role) {
@@ -436,16 +452,43 @@ class InterfaceReference<InterfaceType extends PairInterface>
     final provider = role == PairRole.provider ? this : other;
     final consumer = role == PairRole.consumer ? this : other;
 
-    provider.interface._driveOtherExcept(
-        consumer.interface,
+    if (sameModuleConnectionType == SameModuleConnectionType.passthrough) {
+      if (provider.internalInterface == null) {
+        provider._introduceInternalInterface();
+      }
+      if (consumer.internalInterface == null) {
+        consumer._introduceInternalInterface();
+      }
+    }
+
+    final providerInterface =
+        sameModuleConnectionType == SameModuleConnectionType.passthrough
+            ? provider.internalInterface!
+            : provider.interface;
+    final consumerInterface =
+        sameModuleConnectionType == SameModuleConnectionType.passthrough
+            ? consumer.internalInterface!
+            : consumer.interface;
+
+    final fromProviderSource =
+        sameModuleConnectionType == SameModuleConnectionType.passthrough
+            ? consumerInterface
+            : providerInterface;
+    final fromProviderDestination =
+        sameModuleConnectionType == SameModuleConnectionType.passthrough
+            ? providerInterface
+            : consumerInterface;
+
+    fromProviderSource._driveOtherExcept(
+        fromProviderDestination,
         [
           PairDirection.fromProvider,
           PairDirection.commonInOuts,
         ],
         exceptPorts: exceptPorts);
 
-    consumer.interface._driveOtherExcept(
-        provider.interface,
+    fromProviderDestination._driveOtherExcept(
+        fromProviderSource,
         [
           PairDirection.fromConsumer,
         ],

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -12,17 +12,19 @@
 
 part of 'references.dart';
 
-/// The type of connection to make between two ports on the same module.
+/// The type of connection to make between two ports or interfaces on the same
+/// module.
 ///
-/// When connecting two ports on the same [BridgeModule], the connection can
-/// either be a [loopback] (external, pin-to-pin) or a [passthrough] (internal,
-/// net-to-net).
+/// When connecting ports or interfaces on the same [BridgeModule], the
+/// connection can either be a [loopback] (external, pin-to-pin) or a
+/// [passthrough] (internal, net-to-net).
 ///
 /// For most direction combinations, the connection type is unambiguous and
 /// [PortReference.gets] can infer it automatically. However, when at least one
 /// port is [PortDirection.inOut] and neither port is [PortDirection.input], the
 /// connection type must be explicitly specified via [PortReference.gets] or
-/// `connectPorts`.
+/// [connectPorts]. Interface connections can select the type via
+/// [InterfaceReference.connectTo] or [connectInterfaces].
 enum SameModuleConnectionType {
   /// An external (loopback) connection between ports on the same module.
   ///

--- a/test/intf_hier_conn_test.dart
+++ b/test/intf_hier_conn_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // intf_hier_conn_test.dart
@@ -340,5 +340,119 @@ void main() {
 );
 
 endmodule : leaf'''));
+  });
+
+  test('connect ordinary interfaces with explicit loopback', () async {
+    final leaf = BridgeModule('leaf');
+    final provider =
+        leaf.addInterface(MyIntf(), name: 'provider', role: PairRole.provider);
+    final consumer =
+        leaf.addInterface(MyIntf(), name: 'consumer', role: PairRole.consumer);
+
+    final top = BridgeModule('top')
+      ..addSubModule(leaf)
+      ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
+
+    connectInterfaces(provider, consumer,
+        sameModuleConnectionType: SameModuleConnectionType.loopback);
+
+    await top.build();
+
+    provider.port('myProviderPort').port.put(0x12);
+    expect(consumer.port('myProviderPort').port.value.toInt(), 0x12);
+
+    consumer.port('myConsumerPort').port.put(0x34);
+    expect(provider.port('myConsumerPort').port.value.toInt(), 0x34);
+  });
+
+  test('connect interface ports on the same module with passthrough', () async {
+    final leaf = BridgeModule('leaf');
+    final provider =
+        leaf.addInterface(MyIntf(), name: 'provider', role: PairRole.provider);
+    final consumer =
+        leaf.addInterface(MyIntf(), name: 'consumer', role: PairRole.consumer);
+
+    final top = BridgeModule('top')
+      ..addSubModule(leaf)
+      ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
+
+    connectInterfaces(provider, consumer,
+        sameModuleConnectionType: SameModuleConnectionType.passthrough);
+
+    await top.build();
+
+    expect(
+      provider.internalInterface!.port('myProviderPort').srcConnection,
+      consumer.internalInterface!.port('myProviderPort'),
+    );
+    expect(
+      consumer.internalInterface!.port('myConsumerPort').srcConnection,
+      provider.internalInterface!.port('myConsumerPort'),
+    );
+  });
+
+  for (final connectionType in SameModuleConnectionType.values) {
+    test('connect same-module inOut interfaces with ${connectionType.name}',
+        () async {
+      final leaf = BridgeModule('leaf');
+      final provider = leaf.addInterface(
+        PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
+        name: 'provider',
+        role: PairRole.provider,
+      );
+      final consumer = leaf.addInterface(
+        PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
+        name: 'consumer',
+        role: PairRole.consumer,
+      );
+
+      final top = BridgeModule('top')
+        ..addSubModule(leaf)
+        ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
+
+      connectInterfaces(provider, consumer,
+          sameModuleConnectionType: connectionType);
+
+      await top.build();
+
+      if (connectionType == SameModuleConnectionType.loopback) {
+        expect(
+          consumer.interface.port('bus').srcConnections,
+          contains(provider.interface.port('bus')),
+        );
+      } else {
+        expect(
+          provider.internalInterface!.port('bus').srcConnections,
+          contains(consumer.internalInterface!.port('bus')),
+        );
+      }
+    });
+  }
+
+  test('reject connection type for interfaces on different modules', () {
+    final providerModule = BridgeModule('provider')
+      ..addInterface(MyIntf(), name: 'intf', role: PairRole.provider);
+    final consumerModule = BridgeModule('consumer')
+      ..addInterface(MyIntf(), name: 'intf', role: PairRole.consumer);
+    final top = BridgeModule('top')
+      ..addSubModule(providerModule)
+      ..addSubModule(consumerModule);
+
+    expect(
+      () => connectInterfaces(
+        providerModule.interface('intf'),
+        consumerModule.interface('intf'),
+        sameModuleConnectionType: SameModuleConnectionType.loopback,
+      ),
+      throwsA(
+        isA<RohdBridgeException>().having(
+          (exception) => exception.message,
+          'message',
+          contains('only be provided'),
+        ),
+      ),
+    );
+
+    expect(top.subBridgeModules, hasLength(2));
   });
 }

--- a/test/intf_hier_conn_test.dart
+++ b/test/intf_hier_conn_test.dart
@@ -349,12 +349,12 @@ endmodule : leaf'''));
     final consumer =
         leaf.addInterface(MyIntf(), name: 'consumer', role: PairRole.consumer);
 
+    connectInterfaces(provider, consumer,
+        sameModuleConnectionType: SameModuleConnectionType.loopback);
+
     final top = BridgeModule('top')
       ..addSubModule(leaf)
       ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
-
-    connectInterfaces(provider, consumer,
-        sameModuleConnectionType: SameModuleConnectionType.loopback);
 
     await top.build();
 
@@ -372,12 +372,12 @@ endmodule : leaf'''));
     final consumer =
         leaf.addInterface(MyIntf(), name: 'consumer', role: PairRole.consumer);
 
+    connectInterfaces(provider, consumer,
+        sameModuleConnectionType: SameModuleConnectionType.passthrough);
+
     final top = BridgeModule('top')
       ..addSubModule(leaf)
       ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
-
-    connectInterfaces(provider, consumer,
-        sameModuleConnectionType: SameModuleConnectionType.passthrough);
 
     await top.build();
 
@@ -391,42 +391,54 @@ endmodule : leaf'''));
     );
   });
 
-  for (final connectionType in SameModuleConnectionType.values) {
-    test('connect same-module inOut interfaces with ${connectionType.name}',
-        () async {
-      final leaf = BridgeModule('leaf');
-      final provider = leaf.addInterface(
-        PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
-        name: 'provider',
-        role: PairRole.provider,
-      );
-      final consumer = leaf.addInterface(
-        PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
-        name: 'consumer',
-        role: PairRole.consumer,
-      );
+  for (final parentBeforeConnection in [false, true]) {
+    for (final connectionType in SameModuleConnectionType.values) {
+      final parentingState =
+          parentBeforeConnection ? 'after parenting' : 'before parenting';
 
-      final top = BridgeModule('top')
-        ..addSubModule(leaf)
-        ..pullUpPort(leaf.createPort('dummy', PortDirection.input));
-
-      connectInterfaces(provider, consumer,
-          sameModuleConnectionType: connectionType);
-
-      await top.build();
-
-      if (connectionType == SameModuleConnectionType.loopback) {
-        expect(
-          consumer.interface.port('bus').srcConnections,
-          contains(provider.interface.port('bus')),
+      test(
+          'connect same-module inOut interfaces with ${connectionType.name} '
+          '$parentingState', () async {
+        final leaf = BridgeModule('leaf');
+        final provider = leaf.addInterface(
+          PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
+          name: 'provider',
+          role: PairRole.provider,
         );
-      } else {
-        expect(
-          provider.internalInterface!.port('bus').srcConnections,
-          contains(consumer.internalInterface!.port('bus')),
+        final consumer = leaf.addInterface(
+          PairInterface(commonInOutPorts: [LogicNet.port('bus')]),
+          name: 'consumer',
+          role: PairRole.consumer,
         );
-      }
-    });
+        final top = BridgeModule('top');
+
+        if (parentBeforeConnection) {
+          top.addSubModule(leaf);
+        }
+
+        connectInterfaces(provider, consumer,
+            sameModuleConnectionType: connectionType);
+
+        if (!parentBeforeConnection) {
+          top.addSubModule(leaf);
+        }
+        top.pullUpPort(leaf.createPort('dummy', PortDirection.input));
+
+        await top.build();
+
+        if (connectionType == SameModuleConnectionType.loopback) {
+          expect(
+            consumer.interface.port('bus').srcConnections,
+            contains(provider.interface.port('bus')),
+          );
+        } else {
+          expect(
+            provider.internalInterface!.port('bus').srcConnections,
+            contains(consumer.internalInterface!.port('bus')),
+          );
+        }
+      });
+    }
   }
 
   test('reject connection type for interfaces on different modules', () {

--- a/test/same_module_connection_test.dart
+++ b/test/same_module_connection_test.dart
@@ -232,6 +232,46 @@ void main() {
     });
 
     group('connectPorts()', () {
+      for (final parentBeforeConnection in [false, true]) {
+        for (final connectionType in SameModuleConnectionType.values) {
+          final parentingState =
+              parentBeforeConnection ? 'after parenting' : 'before parenting';
+
+          test(
+              'connects inOut ports with ${connectionType.name} '
+              '$parentingState', () async {
+            final mod = BridgeModule('testMod');
+            final driver =
+                mod.createPort('driver', PortDirection.inOut, width: 8);
+            final receiver =
+                mod.createPort('receiver', PortDirection.inOut, width: 8);
+            final top = BridgeModule('top');
+
+            if (parentBeforeConnection) {
+              top.addSubModule(mod);
+            }
+
+            connectPorts(driver, receiver,
+                sameModuleConnectionType: connectionType);
+
+            if (!parentBeforeConnection) {
+              top.addSubModule(mod);
+            }
+            top.pullUpPort(mod.createPort('dummyIn', PortDirection.input));
+
+            await top.build();
+
+            if (connectionType == SameModuleConnectionType.loopback) {
+              expect(mod.inOutSource('receiver').srcConnections,
+                  contains(mod.inOutSource('driver')));
+            } else {
+              expect(mod.inOut('receiver').srcConnections,
+                  contains(mod.inOut('driver')));
+            }
+          });
+        }
+      }
+
       for (final tc in _testCases) {
         // connectPorts does hierarchy punching; for same-module it passes
         // through to gets().


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

`SameModuleConnectionType` could previously be used for same-module port connections, but `connectInterfaces` did not expose equivalent control for interfaces. This change adds `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo`, allowing callers to select external-facing loopback connections or internal-facing passthrough connections.

The change also rejects `sameModuleConnectionType` when the interfaces belong to different modules and adds coverage for ordinary and `inOut` interfaces.

## Related Issue(s)

None.

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No. The new parameter is optional, and omitting it preserves the existing loopback behavior for same-module interfaces.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes. API documentation for `connectInterfaces`, `InterfaceReference.connectTo`, and `SameModuleConnectionType` has been updated, and the change is included in `CHANGELOG.md`.