### PR TITLE
Support typed structure connection extraction and references

### DIFF
--- a/lib/src/connection_extractor.dart
+++ b/lib/src/connection_extractor.dart
@@ -191,15 +191,22 @@ class _ConnectionSliceTracking {
   BridgeModule get dstModule => dst.parentModule! as BridgeModule;
 
   /// Converts the [src] to a [PortReference].
-  Reference toSrcRef() => src is Const
-      ? ConstReference(
-          src.value,
+  Reference toSrcRef() {
+    if (src is Const) {
+      return ConstReference(
+        src.value,
 
-          // use the `dstModule` since we haven't necessarily built yet and the
-          // source is a `Const`, not a port
-          module: dstModule,
-        )
-      : PortReference.fromPort(src).slice(srcHighIndex, srcLowIndex);
+        // use the `dstModule` since we haven't necessarily built yet and the
+        // source is a `Const`, not a port
+        module: dstModule,
+      );
+    }
+
+    final srcReference = PortReference.fromPort(src);
+    return srcLowIndex == 0 && srcHighIndex == src.width - 1
+        ? srcReference
+        : srcReference.slice(srcHighIndex, srcLowIndex);
+  }
 
   /// Converts the [dst] to a [PortReference].
   PortReference toDstRef() =>
@@ -209,11 +216,7 @@ class _ConnectionSliceTracking {
   int get width => srcHighIndex - srcLowIndex + 1;
 
   /// Nets can connect to themselves, but if its identical, then it's useless.
-  bool isSelfConnection() =>
-      src == dst &&
-      srcLowIndex == dstLowIndex &&
-      srcHighIndex == dstHighIndex &&
-      const ListEquality<int>().equals(dstDimensionAccess, const []);
+  bool isSelfConnection() => src is! Const && toSrcRef() == toDstRef();
 
   /// Creates a new [_ConnectionSliceTracking] instance.
   _ConnectionSliceTracking({
@@ -508,6 +511,10 @@ class ConnectionExtractor {
       var dstLowIndex = 0;
 
       for (final element in load.leafElements) {
+        if (element.width == 0) {
+          continue;
+        }
+
         mappings.addAll(
           _traceDriverForSources(
             _ConnectionSliceTracking(
@@ -778,6 +785,8 @@ class ConnectionExtractor {
     required List<Logic> components,
   }) {
     final foundTrackings = <_ConnectionSliceTracking>[];
+    final nonEmptyComponents =
+        components.where((component) => component.width > 0).toList();
 
     // we need to identify which portions of the dst overlap with which
     // portions of the collection of swizzle inputs, then split the
@@ -792,14 +801,14 @@ class ConnectionExtractor {
       swizzleBitIdx++;
       srcIdx++;
 
-      if (swizzleBitIdx >= components[swizzleIdx].width) {
+      if (swizzleBitIdx >= nonEmptyComponents[swizzleIdx].width) {
         // move to the next swizzle input
         swizzleIdx++;
         swizzleBitIdx = 0;
       }
     }
 
-    assert(swizzleIdx < components.length,
+    assert(swizzleIdx < nonEmptyComponents.length,
         'swizzleIdx should be within bounds of swizzleInputs');
 
     int? currNewDstHighIndex;
@@ -808,18 +817,18 @@ class ConnectionExtractor {
     int? currSwizzleInputLowIndex = swizzleBitIdx;
 
     void checkAndFlushCurrentTracking() {
-      assert(swizzleIdx < components.length,
+      assert(swizzleIdx < nonEmptyComponents.length,
           'swizzleIdx should be within bounds of swizzleInputs');
 
       final hitSwizzleInputEnd =
-          swizzleBitIdx >= components[swizzleIdx].width - 1;
+          swizzleBitIdx >= nonEmptyComponents[swizzleIdx].width - 1;
 
       final hitDstRangeEnd = currNewDstHighIndex != null &&
           currNewDstHighIndex! >= loadTracking.dstHighIndex;
 
       if (hitSwizzleInputEnd || hitDstRangeEnd) {
         if (currNewDstHighIndex != null && currNewDstLowIndex != null) {
-          final currSwizzleInput = components[swizzleIdx];
+          final currSwizzleInput = nonEmptyComponents[swizzleIdx];
 
           final newLoadTracking = loadTracking.copyWith(
             src: currSwizzleInput,

--- a/lib/src/connection_extractor.dart
+++ b/lib/src/connection_extractor.dart
@@ -233,7 +233,9 @@ class _ConnectionSliceTracking {
                 dstLowIndex >= 0 &&
                 dstHighIndex < dst.width,
             'Indices must be within the bounds of the'
-            ' source and destination Logic.');
+            ' source and destination Logic: '
+            '${src.name}[$srcHighIndex:$srcLowIndex] width=${src.width}, '
+            '${dst.name}[$dstHighIndex:$dstLowIndex] width=${dst.width}.');
 
   /// Creates a copy of this [_ConnectionSliceTracking] with new values for some
   /// fields.
@@ -501,6 +503,28 @@ class ConnectionExtractor {
       return [
         for (final element in load.elements) ..._traceDriverForMappings(element)
       ];
+    } else if (load is LogicStructure) {
+      final mappings = <_ConnectionSliceTracking>[];
+      var dstLowIndex = 0;
+
+      for (final element in load.leafElements) {
+        mappings.addAll(
+          _traceDriverForSources(
+            _ConnectionSliceTracking(
+              dst: load,
+              src: element,
+              srcLowIndex: 0,
+              srcHighIndex: element.width - 1,
+              dstLowIndex: dstLowIndex,
+              dstHighIndex: dstLowIndex + element.width - 1,
+              dstDimensionAccess: const [],
+            ),
+          ).whereNot((tracking) => tracking.isSelfConnection()),
+        );
+        dstLowIndex += element.width;
+      }
+
+      return mappings;
     } else {
       return _traceDriverForSources(
         _ConnectionSliceTracking(

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -93,23 +93,64 @@ sealed class PortReference extends Reference {
 
   /// Creates a [PortReference] from an existing [Logic] port.
   ///
-  /// The [port] must be a port of a [BridgeModule]. If the [port] is an array
-  /// member, this will create a [PortReference] that includes the appropriate
-  /// array indexing to access that specific element.
+  /// The [port] must be a port of a [BridgeModule]. For members of a structured
+  /// port, this creates a reference to the corresponding packed range or array
+  /// element of the physical root port.
   factory PortReference.fromPort(Logic port) {
     if (!port.isPort) {
       throw RohdBridgeException('$port is not a port');
     }
 
-    final dimAccesses = <String>[];
-    var currentPort = port;
-    while (currentPort.isArrayMember) {
-      dimAccesses.add('[${currentPort.arrayIndex!}]');
-      currentPort = currentPort.parentStructure!;
+    var rootPort = port;
+    while (rootPort.parentStructure != null) {
+      rootPort = rootPort.parentStructure!;
     }
 
-    return PortReference.fromString(currentPort.parentModule! as BridgeModule,
-        currentPort.name + dimAccesses.reversed.join());
+    bool isRootArrayDimension(LogicStructure structure) {
+      LogicStructure? ancestor = structure;
+      while (ancestor != null) {
+        if (ancestor is! LogicArray) {
+          return false;
+        }
+        ancestor = ancestor.parentStructure;
+      }
+      return true;
+    }
+
+    final dimensionAccesses = <int>[];
+    var packedLowIndex = 0;
+    var currentPort = port;
+    while (currentPort.parentStructure != null) {
+      final parent = currentPort.parentStructure!;
+
+      if (isRootArrayDimension(parent)) {
+        dimensionAccesses.add(currentPort.arrayIndex!);
+      } else {
+        for (final sibling in parent.elements) {
+          if (identical(sibling, currentPort)) {
+            break;
+          }
+          packedLowIndex += sibling.width;
+        }
+      }
+
+      currentPort = parent;
+    }
+
+    final reference = PortReference.fromString(
+      rootPort.parentModule! as BridgeModule,
+      rootPort.name +
+          dimensionAccesses.reversed.map((index) => '[$index]').join(),
+    );
+
+    if (packedLowIndex == 0 && port.width == reference.width) {
+      return reference;
+    }
+
+    return reference.slice(
+      packedLowIndex + port.width - 1,
+      packedLowIndex,
+    );
   }
 
   @override

--- a/lib/src/references/slice_port_reference.dart
+++ b/lib/src/references/slice_port_reference.dart
@@ -297,6 +297,18 @@ class SlicePortReference extends PortReference {
     otherDriver = _insertIntermediateSignalIfNeeded(
         otherDriver, intermediateSignalName, other);
 
+    if (receiverPort is LogicStructure && receiverPort is! LogicArray) {
+      final driver = otherDriver is Logic
+          ? otherDriver
+          : (otherDriver as List<Logic>).rswizzle();
+      _assignPackedStructureSubset(
+        receiverPort,
+        driver,
+        start: dimensionAccess?.single ?? sliceLowerIndex ?? 0,
+      );
+      return;
+    }
+
     if (otherDriver is Logic) {
       if (leafIndex != null) {
         receiverPort.assignSubset([otherDriver], start: leafIndex);
@@ -385,7 +397,8 @@ class SlicePortReference extends PortReference {
 
     if (dimensionAccess != null) {
       for (final index in dimensionAccess!) {
-        final elementWidth = portElement.elements.first.width;
+        final elementWidth =
+            portElement is LogicArray ? portElement.elements.first.width : 1;
         lower += index * elementWidth;
         upper = lower + elementWidth - 1;
 
@@ -396,7 +409,8 @@ class SlicePortReference extends PortReference {
     }
 
     if (hasSlicing) {
-      final elementWidth = portElement.elements.first.width;
+      final elementWidth =
+          portElement is LogicArray ? portElement.elements.first.width : 1;
       lower += sliceLowerIndex! * elementWidth;
       upper =
           lower + (sliceUpperIndex! - sliceLowerIndex! + 1) * elementWidth - 1;
@@ -412,7 +426,7 @@ class SlicePortReference extends PortReference {
 
     if (dimensionAccess != null) {
       for (final index in dimensionAccess!) {
-        d = d.elements[index];
+        d = d is LogicArray ? d.elements[index] : d[index];
       }
     }
 
@@ -540,6 +554,15 @@ class SlicePortReference extends PortReference {
     _connectOverlappingInterfacePortMaps();
 
     var receiver = _externalPort;
+    if (receiver is LogicStructure && receiver is! LogicArray) {
+      _assignPackedStructureSubset(
+        receiver,
+        other,
+        start: dimensionAccess?.single ?? sliceLowerIndex ?? 0,
+      );
+      return;
+    }
+
     // we must look at the *port* for dimension analysis
     int? leafIndex;
     var startIdx = 0;
@@ -632,6 +655,10 @@ class SlicePortReference extends PortReference {
 
   @override
   PortReference slice(int endIndex, int startIndex) {
+    if (startIndex == 0 && endIndex == width - 1) {
+      return this;
+    }
+
     final (newLowerIndex, newUpperIndex) =
         getUpdatedSliceIndices(endIndex, startIndex);
 
@@ -642,6 +669,44 @@ class SlicePortReference extends PortReference {
       sliceLowerIndex: newLowerIndex,
       sliceUpperIndex: newUpperIndex,
     );
+  }
+
+  static void _assignPackedStructureSubset(
+    LogicStructure receiver,
+    Logic driver, {
+    required int start,
+  }) {
+    final end = start + driver.width;
+    if (start < 0 || end > receiver.width) {
+      throw SignalWidthMismatchException.forWidthOverflow(
+        driver.width,
+        receiver.width - start,
+      );
+    }
+
+    var leafStart = 0;
+    for (final leaf in receiver.leafElements) {
+      final leafEnd = leafStart + leaf.width;
+      final overlapStart = start > leafStart ? start : leafStart;
+      final overlapEnd = end < leafEnd ? end : leafEnd;
+
+      if (overlapStart < overlapEnd) {
+        final driverSubset = driver.getRange(
+          overlapStart - start,
+          overlapEnd - start,
+        );
+        if (overlapStart == leafStart && overlapEnd == leafEnd) {
+          leaf <= driverSubset;
+        } else {
+          leaf.assignSubset(
+            driverSubset.elements,
+            start: overlapStart - leafStart,
+          );
+        }
+      }
+
+      leafStart = leafEnd;
+    }
   }
 
   /// The parent [PortReference] of this [SlicePortReference], with slicing or

--- a/test/connection_extractor_test.dart
+++ b/test/connection_extractor_test.dart
@@ -26,6 +26,54 @@ class MyNetIntf extends PairInterface {
   MyNetIntf clone() => MyNetIntf();
 }
 
+class CompositeWord extends LogicStructure {
+  final Logic control;
+  final Logic payload;
+  final Logic checksum;
+
+  factory CompositeWord({String name = 'compositeWord'}) => CompositeWord._(
+        Logic(name: 'control', width: 4),
+        Logic(name: 'payload', width: 9),
+        Logic(name: 'checksum', width: 2),
+        name: name,
+      );
+
+  CompositeWord._(
+    this.control,
+    this.payload,
+    this.checksum, {
+    required String name,
+  }) : super([control, payload, checksum], name: name);
+
+  @override
+  CompositeWord clone({String? name}) => CompositeWord(name: name ?? this.name);
+}
+
+class ArrayBackedWord extends LogicStructure {
+  final Logic marker;
+  final LogicArray lanes;
+  final Logic status;
+
+  factory ArrayBackedWord({String name = 'arrayBackedWord'}) =>
+      ArrayBackedWord._(
+        Logic(name: 'marker', width: 2),
+        LogicArray([3], 4, name: 'lanes'),
+        Logic(name: 'status', width: 3),
+        name: name,
+      );
+
+  ArrayBackedWord._(
+    this.marker,
+    this.lanes,
+    this.status, {
+    required String name,
+  }) : super([marker, lanes, status], name: name);
+
+  @override
+  ArrayBackedWord clone({String? name}) =>
+      ArrayBackedWord(name: name ?? this.name);
+}
+
 void main() {
   test('simple port to port same hierarchy', () async {
     final sub1 = BridgeModule('sub1')
@@ -54,6 +102,78 @@ void main() {
     final connection = extractor.connections.first as AdHocConnection;
     expect(connection.src.portName, 'mySrc');
     expect(connection.dst.portName, 'myDst');
+  });
+
+  test('splits composite ports by packed fields', () async {
+    final encoder = BridgeModule('encoder')
+      ..addTypedOutput(
+        'frame',
+        ({name = 'frame'}) => CompositeWord(name: name),
+      )
+      ..createPort('clock', PortDirection.input);
+    final decoder = BridgeModule('decoder')
+      ..addTypedInput('sample', CompositeWord());
+    final top = BridgeModule('top')
+      ..addSubModule(encoder)
+      ..addSubModule(decoder);
+
+    encoder.port('clock').punchUpTo(top);
+    connectPorts(encoder.port('frame'), decoder.port('sample'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+
+    expect(extractor.connections, {
+      AdHocConnection(
+        encoder.port('frame').slice(3, 0),
+        decoder.port('sample').slice(3, 0),
+      ),
+      AdHocConnection(
+        encoder.port('frame').slice(12, 4),
+        decoder.port('sample').slice(12, 4),
+      ),
+      AdHocConnection(
+        encoder.port('frame').slice(14, 13),
+        decoder.port('sample').slice(14, 13),
+      ),
+    });
+  });
+
+  test('treats nested arrays in composite ports as packed fields', () async {
+    final packer = BridgeModule('packer')
+      ..addTypedOutput(
+        'encoded',
+        ({name = 'encoded'}) => ArrayBackedWord(name: name),
+      )
+      ..createPort('clock', PortDirection.input);
+    final unpacker = BridgeModule('unpacker')
+      ..addTypedInput('decoded', ArrayBackedWord());
+    final top = BridgeModule('top')
+      ..addSubModule(packer)
+      ..addSubModule(unpacker);
+
+    packer.port('clock').punchUpTo(top);
+    connectPorts(packer.port('encoded'), unpacker.port('decoded'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+    final expectedRanges = [
+      (high: 1, low: 0),
+      (high: 5, low: 2),
+      (high: 9, low: 6),
+      (high: 13, low: 10),
+      (high: 16, low: 14),
+    ];
+
+    expect(extractor.connections, {
+      for (final range in expectedRanges)
+        AdHocConnection(
+          packer.port('encoded').slice(range.high, range.low),
+          unpacker.port('decoded').slice(range.high, range.low),
+        ),
+    });
   });
 
   test('simple intf to intf same hierarchy', () async {

--- a/test/connection_extractor_test.dart
+++ b/test/connection_extractor_test.dart
@@ -74,6 +74,77 @@ class ArrayBackedWord extends LogicStructure {
       ArrayBackedWord(name: name ?? this.name);
 }
 
+class NestedWordPart extends LogicStructure {
+  final Logic code;
+  final Logic count;
+
+  factory NestedWordPart({String name = 'nestedWordPart'}) => NestedWordPart._(
+        Logic(name: 'code', width: 2),
+        Logic(name: 'count', width: 3),
+        name: name,
+      );
+
+  NestedWordPart._(this.code, this.count, {required String name})
+      : super([code, count], name: name);
+
+  @override
+  NestedWordPart clone({String? name}) =>
+      NestedWordPart(name: name ?? this.name);
+}
+
+class NestedWord extends LogicStructure {
+  final Logic flag;
+  final NestedWordPart details;
+  final Logic data;
+
+  factory NestedWord({String name = 'nestedWord'}) => NestedWord._(
+        Logic(name: 'flag'),
+        NestedWordPart(),
+        Logic(name: 'data', width: 4),
+        name: name,
+      );
+
+  NestedWord._(this.flag, this.details, this.data, {required String name})
+      : super([flag, details, data], name: name);
+
+  @override
+  NestedWord clone({String? name}) => NestedWord(name: name ?? this.name);
+}
+
+class SparseWord extends LogicStructure {
+  final Logic empty;
+  final Logic data;
+
+  factory SparseWord({String name = 'sparseWord'}) => SparseWord._(
+        Logic(name: 'empty', width: 0),
+        Logic(name: 'data', width: 3),
+        name: name,
+      );
+
+  SparseWord._(this.empty, this.data, {required String name})
+      : super([empty, data], name: name);
+
+  @override
+  SparseWord clone({String? name}) => SparseWord(name: name ?? this.name);
+}
+
+class NetWord extends LogicStructure {
+  final LogicNet request;
+  final LogicNet response;
+
+  factory NetWord({String name = 'netWord'}) => NetWord._(
+        LogicNet(name: 'request', width: 2),
+        LogicNet(name: 'response', width: 3),
+        name: name,
+      );
+
+  NetWord._(this.request, this.response, {required String name})
+      : super([request, response], name: name);
+
+  @override
+  NetWord clone({String? name}) => NetWord(name: name ?? this.name);
+}
+
 void main() {
   test('simple port to port same hierarchy', () async {
     final sub1 = BridgeModule('sub1')
@@ -173,6 +244,137 @@ void main() {
           packer.port('encoded').slice(range.high, range.low),
           unpacker.port('decoded').slice(range.high, range.low),
         ),
+    });
+  });
+
+  test('extracts nested composite ports by packed leaves', () async {
+    final producer = BridgeModule('producer')
+      ..addTypedOutput(
+        'source',
+        ({name = 'source'}) => NestedWord(name: name),
+      )
+      ..createPort('clock', PortDirection.input);
+    final consumer = BridgeModule('consumer')
+      ..addTypedInput('destination', NestedWord());
+    final top = BridgeModule('top')
+      ..addSubModule(producer)
+      ..addSubModule(consumer);
+
+    producer.port('clock').punchUpTo(top);
+    connectPorts(producer.port('source'), consumer.port('destination'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+    final expectedRanges = [
+      (high: 0, low: 0),
+      (high: 2, low: 1),
+      (high: 5, low: 3),
+      (high: 9, low: 6),
+    ];
+
+    expect(extractor.connections, {
+      for (final range in expectedRanges)
+        AdHocConnection(
+          producer.port('source').slice(range.high, range.low),
+          consumer.port('destination').slice(range.high, range.low),
+        ),
+    });
+  });
+
+  test('connects and ties off composite port members', () async {
+    final producer = BridgeModule('producer')
+      ..addTypedOutput(
+        'source',
+        ({name = 'source'}) => NestedWord(name: name),
+      )
+      ..createPort('clock', PortDirection.input);
+    final consumer = BridgeModule('consumer')
+      ..addTypedInput('destination', NestedWord());
+    final top = BridgeModule('top')
+      ..addSubModule(producer)
+      ..addSubModule(consumer);
+    final source = producer.output('source') as NestedWord;
+    final destination = consumer.input('destination') as NestedWord;
+
+    producer.port('clock').punchUpTo(top);
+    PortReference.fromPort(destination.details.code)
+        .gets(PortReference.fromPort(source.details.code));
+    PortReference.fromPort(destination.details.count).tieOff(value: 5);
+
+    await top.build();
+
+    final connections = ConnectionExtractor(top.subBridgeModules).connections;
+    final adHocConnection = connections.whereType<AdHocConnection>().single;
+    final tieOffConnection = connections.whereType<TieOffConnection>().single;
+
+    expect(
+      adHocConnection,
+      AdHocConnection(
+        producer.port('source').slice(2, 1),
+        consumer.port('destination').slice(2, 1),
+      ),
+    );
+    expect(
+      tieOffConnection.dst,
+      consumer.port('destination').slice(5, 3),
+    );
+    expect(tieOffConnection.src.value, LogicValue.ofInt(5, 3));
+  });
+
+  test('ignores zero-width composite port leaves', () async {
+    final producer = BridgeModule('producer')
+      ..addTypedOutput(
+        'source',
+        ({name = 'source'}) => SparseWord(name: name),
+      )
+      ..createPort('clock', PortDirection.input);
+    final consumer = BridgeModule('consumer')
+      ..addTypedInput('destination', SparseWord());
+    final top = BridgeModule('top')
+      ..addSubModule(producer)
+      ..addSubModule(consumer);
+
+    producer.port('clock').punchUpTo(top);
+    connectPorts(producer.port('source'), consumer.port('destination'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+
+    expect(extractor.connections, {
+      AdHocConnection(
+        producer.port('source'),
+        consumer.port('destination'),
+      ),
+    });
+  });
+
+  test('extracts composite net ports without self-connections', () async {
+    final first = BridgeModule('first')
+      ..addTypedInOut('bus', NetWord())
+      ..createPort('clock', PortDirection.input);
+    final second = BridgeModule('second')..addTypedInOut('bus', NetWord());
+    final top = BridgeModule('top')
+      ..addSubModule(first)
+      ..addSubModule(second);
+
+    first.port('clock').punchUpTo(top);
+    connectPorts(first.port('bus'), second.port('bus'));
+
+    await top.build();
+
+    final extractor = ConnectionExtractor(top.subBridgeModules);
+
+    expect(extractor.connections, {
+      AdHocConnection(
+        first.port('bus').slice(1, 0),
+        second.port('bus').slice(1, 0),
+      ),
+      AdHocConnection(
+        first.port('bus').slice(4, 2),
+        second.port('bus').slice(4, 2),
+      ),
     });
   });
 


### PR DESCRIPTION
## Description & Motivation

Add support for extracting connections involving typed `LogicStructure` ports.

Structured ports are traced at leaf granularity and converted back into packed ranges of their physical root ports. Nested structures and arrays contained within structures are handled according to their packed layout, while root `LogicArray` ports retain dimensional access syntax.

This also fixes adjacent structured-port behavior:

- Connections and tie-offs through `PortReference.fromPort` for structure members now use packed bit ranges.
- Nested one-bit structure members no longer produce redundant indexing.
- Zero-width structure leaves are ignored during extraction and concatenation tracing.
- Net-backed typed structure ports no longer produce redundant self-connections.
- Connection tracking assertions now include source and destination range details.

## Related Issue(s)

None.

## Testing

Added regression coverage for:

- Typed structure port extraction.
- Arrays nested within packed structures.
- Nested ordinary structures.
- Connections and tie-offs through structure member references.
- Zero-width structure leaves.
- Net-backed typed inout structures.
- Existing root-array behavior.

## Backwards-compatibility

No public API changes are intended. Existing flat ports and root `LogicArray` references retain their current behavior. Structured-port references that were previously rejected or represented incorrectly now resolve to their packed physical ranges.

## Documentation

No documentation changes are required. The supported behavior is covered by API documentation and regression tests.