### PR TITLE
Optimize ConnectionExtractor tracing and add performance benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions and repeated interface-connection scans, and added a synthetic benchmark for regression measurement.
+- Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions and repeated interface-connection scans, and added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions and repeated interface-connection scans, and added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
+- Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions, caching repeated interface and canonical port-reference lookups, and indexing interface-covered ports. Added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions and repeated interface-connection scans, and added a synthetic benchmark for regression measurement.
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).
 - Added `tryInterface`, `typedInterface`, and `tryTypedInterface` for nullable and type-preserving interface lookup (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,36 @@
+# Benchmarking ROHD Bridge
+
+This directory contains synthetic benchmarks for comparing the relative
+performance of ROHD Bridge features before and after a change.
+
+Run all benchmarks with:
+
+```shell
+dart run benchmark/benchmark.dart
+```
+
+Run only the connection extractor benchmark with:
+
+```shell
+dart run benchmark/connection_extractor_benchmark.dart
+```
+
+The default connection extractor design uses only public ROHD and ROHD Bridge
+APIs. It contains 64 child modules, 160 complete interface connections, and
+2,048 ad-hoc port connections. The benchmark validates these structural
+results before reporting timings:
+
+| Result | Expected |
+| --- | ---: |
+| Child modules | 64 |
+| Physical child ports | 9,248 |
+| Interface-aware connections | 2,208 |
+| Pin-only connections | 4,608 |
+
+Compare results on the same host and Dart version. Do not use absolute timing
+assertions in tests; timings vary by runtime and machine.
+
+---
+
+Copyright (C) 2026 Intel Corporation  
+SPDX-License-Identifier: BSD-3-Clause

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// benchmark.dart
+// Runs all ROHD Bridge benchmarks.
+//
+// 2026 August 20
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'connection_extractor_benchmark.dart' as connection_extractor;
+
+Future<void> main() async {
+  await connection_extractor.main();
+}

--- a/benchmark/connection_extractor_benchmark.dart
+++ b/benchmark/connection_extractor_benchmark.dart
@@ -1,0 +1,210 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// connection_extractor_benchmark.dart
+// Benchmarks extracting connections from a large synthetic design.
+//
+// 2026 August 20
+// Author: Max Korbel <max.korbel@intel.com>
+
+// Benchmark declarations are public so that the benchmark smoke test can
+// import them, but they are not part of the package's public API.
+// ignore_for_file: avoid_print
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_bridge/rohd_bridge.dart';
+
+class BenchmarkPairInterface extends PairInterface {
+  BenchmarkPairInterface(this.portsPerDirection)
+      : super(
+          portsFromProvider: [
+            for (var i = 0; i < portsPerDirection; i++)
+              Logic.port('request_$i', 1 + i % 32),
+          ],
+          portsFromConsumer: [
+            for (var i = 0; i < portsPerDirection; i++)
+              Logic.port('response_$i', 1 + (i * 3) % 32),
+          ],
+        );
+
+  final int portsPerDirection;
+
+  @override
+  BenchmarkPairInterface clone() => BenchmarkPairInterface(portsPerDirection);
+}
+
+class ConnectionExtractorBenchmarkDesign {
+  ConnectionExtractorBenchmarkDesign({
+    this.modulePairs = 32,
+    this.interfacesPerPair = 5,
+    this.portsPerDirection = 8,
+    this.adHocConnectionsPerPair = 64,
+  }) : top = BridgeModule('connection_extractor_benchmark_top') {
+    for (var pair = 0; pair < modulePairs; pair++) {
+      final provider = BridgeModule('benchmark_provider')
+        ..createPort('clock', PortDirection.input);
+      final consumer = BridgeModule('benchmark_consumer');
+
+      for (var interfaceIndex = 0;
+          interfaceIndex < interfacesPerPair;
+          interfaceIndex++) {
+        final interfaceName = 'bus_$interfaceIndex';
+        provider.addInterface(
+          BenchmarkPairInterface(portsPerDirection),
+          name: interfaceName,
+          role: PairRole.provider,
+        );
+        consumer.addInterface(
+          BenchmarkPairInterface(portsPerDirection),
+          name: interfaceName,
+          role: PairRole.consumer,
+        );
+      }
+
+      for (var connection = 0;
+          connection < adHocConnectionsPerPair;
+          connection++) {
+        final width = 1 + connection % 64;
+        provider.createPort(
+          'source_$connection',
+          PortDirection.output,
+          width: width,
+        );
+        consumer.createPort(
+          'destination_$connection',
+          PortDirection.input,
+          width: width,
+        );
+      }
+
+      top
+        ..addSubModule(provider)
+        ..addSubModule(consumer);
+      provider.port('clock').punchUpTo(top, newPortName: 'clock_$pair');
+
+      for (var interfaceIndex = 0;
+          interfaceIndex < interfacesPerPair;
+          interfaceIndex++) {
+        final interfaceName = 'bus_$interfaceIndex';
+        connectInterfaces(
+          provider.interface(interfaceName),
+          consumer.interface(interfaceName),
+        );
+      }
+
+      for (var connection = 0;
+          connection < adHocConnectionsPerPair;
+          connection++) {
+        connectPorts(
+          provider.port('source_$connection'),
+          consumer.port('destination_$connection'),
+        );
+      }
+    }
+  }
+
+  final int modulePairs;
+  final int interfacesPerPair;
+  final int portsPerDirection;
+  final int adHocConnectionsPerPair;
+  final BridgeModule top;
+
+  Iterable<BridgeModule> get modules => top.subBridgeModules;
+
+  int get expectedModuleCount => 2 * modulePairs;
+
+  int get expectedPhysicalPortCount =>
+      modulePairs *
+      (1 +
+          4 * interfacesPerPair * portsPerDirection +
+          2 * adHocConnectionsPerPair);
+
+  int get expectedCompactConnectionCount =>
+      modulePairs * (interfacesPerPair + adHocConnectionsPerPair);
+
+  int get expectedPinConnectionCount =>
+      modulePairs *
+      (2 * interfacesPerPair * portsPerDirection + adHocConnectionsPerPair);
+
+  int get physicalPortCount => modules.fold(
+        0,
+        (count, module) =>
+            count +
+            module.inputs.length +
+            module.outputs.length +
+            module.inOuts.length,
+      );
+
+  void validateStructure() {
+    if (modules.length != expectedModuleCount) {
+      throw StateError(
+        'Expected $expectedModuleCount modules, found ${modules.length}.',
+      );
+    }
+    if (physicalPortCount != expectedPhysicalPortCount) {
+      throw StateError(
+        'Expected $expectedPhysicalPortCount physical ports, '
+        'found $physicalPortCount.',
+      );
+    }
+  }
+}
+
+class ConnectionExtractorBenchmark extends BenchmarkBase {
+  ConnectionExtractorBenchmark(
+    Iterable<BridgeModule> modules, {
+    required this.includeInterfaceConnections,
+    required this.expectedConnectionCount,
+  })  : modules = List.unmodifiable(modules),
+        super(
+          includeInterfaceConnections
+              ? 'ConnectionExtractor.interfaceAware'
+              : 'ConnectionExtractor.pinOnly',
+        );
+
+  final List<BridgeModule> modules;
+  final bool includeInterfaceConnections;
+  final int expectedConnectionCount;
+
+  Set<Connection> latestConnections = const {};
+
+  @override
+  void run() {
+    latestConnections = ConnectionExtractor(
+      modules,
+      includeInterfaceConnections: includeInterfaceConnections,
+    ).connections;
+
+    if (latestConnections.length != expectedConnectionCount) {
+      throw StateError(
+        'Expected $expectedConnectionCount connections, '
+        'found ${latestConnections.length}.',
+      );
+    }
+  }
+}
+
+Future<void> main() async {
+  final design = ConnectionExtractorBenchmarkDesign();
+  final buildWatch = Stopwatch()..start();
+  await design.top.build();
+  buildWatch.stop();
+  design.validateStructure();
+
+  print(
+    'build=${buildWatch.elapsedMilliseconds}ms '
+    'modules=${design.modules.length} ports=${design.physicalPortCount}',
+  );
+
+  ConnectionExtractorBenchmark(
+    design.modules,
+    includeInterfaceConnections: true,
+    expectedConnectionCount: design.expectedCompactConnectionCount,
+  ).report();
+  ConnectionExtractorBenchmark(
+    design.modules,
+    includeInterfaceConnections: false,
+    expectedConnectionCount: design.expectedPinConnectionCount,
+  ).report();
+}

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,12 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# dart_test.yaml
+# Test runner configuration.
+#
+# 2026 August 20
+# Author: Max Korbel <max.korbel@intel.com>
+
+tags:
+  benchmark:
+    timeout: 2x

--- a/lib/src/connection_extractor.dart
+++ b/lib/src/connection_extractor.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // connection_extractor.dart
@@ -145,6 +145,7 @@ class AdHocConnection extends Connection<PortReference>
   /// Creates a new [AdHocConnection] between two [PortReference]s.
   const AdHocConnection(super.point1, super.point2);
 
+  /// The visual connector representing this connection's directionality.
   String get _connectorString => isNet ? '<-->' : '--->';
 
   @override
@@ -278,14 +279,15 @@ class _ConnectionSliceTracking {
           .equals(other.dstDimensionAccess, dstDimensionAccess);
 
   @override
-  int get hashCode =>
-      src.hashCode ^
-      srcLowIndex.hashCode ^
-      srcHighIndex.hashCode ^
-      dst.hashCode ^
-      dstLowIndex.hashCode ^
-      dstHighIndex.hashCode ^
-      const ListEquality<int>().hash(dstDimensionAccess);
+  int get hashCode => Object.hash(
+        src,
+        srcLowIndex,
+        srcHighIndex,
+        dst,
+        dstLowIndex,
+        dstHighIndex,
+        Object.hashAll(dstDimensionAccess),
+      );
 }
 
 /// Analyzes a set of modules and provides connection information between them.
@@ -297,6 +299,8 @@ class ConnectionExtractor {
   /// extractor, so if the modules change, you will need to create a new
   /// extractor to get the updated connections.
   Set<Connection> get connections => UnmodifiableSetView(_connections);
+
+  /// The mutable backing set for [connections].
   final Set<Connection> _connections = {};
 
   /// The set of modules to analyze for connections.
@@ -306,6 +310,25 @@ class ConnectionExtractor {
   /// [InterfaceConnection]s. Set this to `false` if you want only ad-hoc
   /// connections (and tie-offs).
   final bool includeInterfaceConnections;
+
+  /// Interface port references cached for the lifetime of this extractor.
+  final Map<InterfaceReference, List<InterfacePortReference>> _interfacePorts =
+      {};
+
+  /// Interface completeness results cached for the lifetime of this
+  /// extractor.
+  final Map<InterfaceReference, bool> _fullyConnectedInterfaces = {};
+
+  /// Returns the port references captured for [interface] during extraction.
+  List<InterfacePortReference> _portsFor(InterfaceReference interface) =>
+      _interfacePorts.putIfAbsent(interface, () => interface.ports);
+
+  /// Returns whether [interface] was fully connected when first inspected.
+  bool _isFullyConnected(InterfaceReference interface) =>
+      _fullyConnectedInterfaces.putIfAbsent(
+        interface,
+        () => interface.isFullyConnected,
+      );
 
   /// Creates a new [ConnectionExtractor] for the given [modules] which will
   /// then identify [connections] between them.
@@ -325,11 +348,11 @@ class ConnectionExtractor {
   void _findInterfaceConnections() {
     for (final module in modules) {
       for (final intf in module.interfaces.values) {
-        if (!intf.isFullyConnected) {
+        if (!_isFullyConnected(intf)) {
           continue;
         }
 
-        if (intf.ports
+        if (_portsFor(intf)
             .where((p) =>
                 p.direction == PortDirection.input ||
                 p.direction == PortDirection.inOut)
@@ -344,7 +367,7 @@ class ConnectionExtractor {
         // find all the InterfaceReferences connected to *any* ports of this one
         final modulesConnectedToIntf = <BridgeModule>{};
 
-        for (final intfPort in intf.ports) {
+        for (final intfPort in _portsFor(intf)) {
           final portsOnMod = intf.portMaps
               .where((e) => e.interfacePort == intfPort)
               .map((e) => e.port);
@@ -363,7 +386,7 @@ class ConnectionExtractor {
               continue; // don't connect to self
             }
 
-            if (!otherIntf.isFullyConnected) {
+            if (!_isFullyConnected(otherIntf)) {
               continue; // skip if not fully connected
             }
 
@@ -378,7 +401,7 @@ class ConnectionExtractor {
 
             // check if *every* port of otherIntf is connected FULLY to intf
             // and in both directions
-            final allOtherIntfInpsDriven = otherIntf.ports
+            final allOtherIntfInpsDriven = _portsFor(otherIntf)
                 .where((p) =>
                     p.direction == PortDirection.input ||
                     p.direction == PortDirection.inOut)
@@ -400,7 +423,7 @@ class ConnectionExtractor {
               );
             });
 
-            final allThisIntfInpsDriven = intf.ports
+            final allThisIntfInpsDriven = _portsFor(intf)
                 .where((p) =>
                     p.direction == PortDirection.input ||
                     p.direction == PortDirection.inOut)
@@ -435,6 +458,13 @@ class ConnectionExtractor {
   void _findAdHocConnections() {
     final adHocConnections = <AdHocConnection>[];
     final tieOffConnections = <TieOffConnection>[];
+    final portsCoveredByInterfaces = connections
+        .whereType<InterfaceConnection>()
+        .expand((connection) => [connection.point1, connection.point2])
+        .expand((interface) => interface.portMaps)
+        .map((portMap) => portMap.port)
+        .toSet();
+
     for (final module in modules) {
       for (final port in [
         ...module.inputs.values,
@@ -447,24 +477,8 @@ class ConnectionExtractor {
           final srcRef = mapping.toSrcRef();
           final dstRef = mapping.toDstRef();
 
-          final thisModIsIntfConn = connections
-              .whereType<InterfaceConnection>()
-              .map((e) => e.pointForModule(module))
-              .nonNulls
-              .any((intfRef) => intfRef.portMaps.any(
-                    (pm) => pm.port == dstRef,
-                  ));
-
-          final otherModule = srcRef.module;
-          final otherModIsIntfConn = connections
-              .whereType<InterfaceConnection>()
-              .map((e) => e.pointForModule(otherModule))
-              .nonNulls
-              .any((intfRef) => intfRef.portMaps.any(
-                    (pm) => pm.port == srcRef,
-                  ));
-
-          if (thisModIsIntfConn && otherModIsIntfConn) {
+          if (portsCoveredByInterfaces.contains(dstRef) &&
+              portsCoveredByInterfaces.contains(srcRef)) {
             // if both modules are already connected via an interface, skip
             continue;
           }

--- a/lib/src/connection_extractor.dart
+++ b/lib/src/connection_extractor.dart
@@ -7,6 +7,8 @@
 // 2025 June
 // Author: Max Korbel <max.korbel@intel.com>
 
+import 'dart:collection';
+
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
@@ -159,6 +161,9 @@ class AdHocConnection extends Connection<PortReference>
       complex;
 }
 
+/// Resolves the canonical [PortReference] for a physical [Logic] port.
+typedef _PortReferenceResolver = PortReference Function(Logic port);
+
 /// A structure for tracking slicing information during tracing.
 @immutable
 class _ConnectionSliceTracking {
@@ -191,8 +196,8 @@ class _ConnectionSliceTracking {
   /// The module of the [dst].
   BridgeModule get dstModule => dst.parentModule! as BridgeModule;
 
-  /// Converts the [src] to a [PortReference].
-  Reference toSrcRef() {
+  /// Converts the [src] using [fullPortReference].
+  Reference toSrcRef(_PortReferenceResolver fullPortReference) {
     if (src is Const) {
       return ConstReference(
         src.value,
@@ -203,21 +208,23 @@ class _ConnectionSliceTracking {
       );
     }
 
-    final srcReference = PortReference.fromPort(src);
+    final srcReference = fullPortReference(src);
     return srcLowIndex == 0 && srcHighIndex == src.width - 1
         ? srcReference
         : srcReference.slice(srcHighIndex, srcLowIndex);
   }
 
-  /// Converts the [dst] to a [PortReference].
-  PortReference toDstRef() =>
-      PortReference.fromPort(dst).slice(dstHighIndex, dstLowIndex);
+  /// Converts the [dst] using [fullPortReference].
+  PortReference toDstRef(_PortReferenceResolver fullPortReference) =>
+      fullPortReference(dst).slice(dstHighIndex, dstLowIndex);
 
   /// The width of the tracking currently.
   int get width => srcHighIndex - srcLowIndex + 1;
 
-  /// Nets can connect to themselves, but if its identical, then it's useless.
-  bool isSelfConnection() => src is! Const && toSrcRef() == toDstRef();
+  /// Whether this describes a net connected to the identical reference.
+  bool isSelfConnection(_PortReferenceResolver fullPortReference) =>
+      src is! Const &&
+      toSrcRef(fullPortReference) == toDstRef(fullPortReference);
 
   /// Creates a new [_ConnectionSliceTracking] instance.
   _ConnectionSliceTracking({
@@ -319,6 +326,9 @@ class ConnectionExtractor {
   /// extractor.
   final Map<InterfaceReference, bool> _fullyConnectedInterfaces = {};
 
+  /// Canonical port references cached by [Logic] identity for this extraction.
+  final HashMap<Logic, PortReference> _portReferences = HashMap.identity();
+
   /// Returns the port references captured for [interface] during extraction.
   List<InterfacePortReference> _portsFor(InterfaceReference interface) =>
       _interfacePorts.putIfAbsent(interface, () => interface.ports);
@@ -329,6 +339,10 @@ class ConnectionExtractor {
         interface,
         () => interface.isFullyConnected,
       );
+
+  /// Returns the canonical reference captured for [port] during extraction.
+  PortReference _fullPortReference(Logic port) =>
+      _portReferences.putIfAbsent(port, () => PortReference.fromPort(port));
 
   /// Creates a new [ConnectionExtractor] for the given [modules] which will
   /// then identify [connections] between them.
@@ -418,7 +432,8 @@ class ConnectionExtractor {
                       (testIntf) =>
                           testIntf == intf &&
                           testIntf.portMaps.any((pm) =>
-                              pm.isConnected && pm.port == mapping.toSrcRef()),
+                              pm.isConnected &&
+                              pm.port == mapping.toSrcRef(_fullPortReference)),
                     ),
               );
             });
@@ -440,7 +455,8 @@ class ConnectionExtractor {
                       (testIntf) =>
                           testIntf == otherIntf &&
                           testIntf.portMaps.any((pm) =>
-                              pm.isConnected && pm.port == mapping.toSrcRef()),
+                              pm.isConnected &&
+                              pm.port == mapping.toSrcRef(_fullPortReference)),
                     ),
               );
             });
@@ -474,8 +490,8 @@ class ConnectionExtractor {
         final mappings = _traceDriverForMappings(port);
 
         for (final mapping in mappings) {
-          final srcRef = mapping.toSrcRef();
-          final dstRef = mapping.toDstRef();
+          final srcRef = mapping.toSrcRef(_fullPortReference);
+          final dstRef = mapping.toDstRef(_fullPortReference);
 
           if (portsCoveredByInterfaces.contains(dstRef) &&
               portsCoveredByInterfaces.contains(srcRef)) {
@@ -540,7 +556,9 @@ class ConnectionExtractor {
               dstHighIndex: dstLowIndex + element.width - 1,
               dstDimensionAccess: const [],
             ),
-          ).whereNot((tracking) => tracking.isSelfConnection()),
+          ).whereNot(
+            (tracking) => tracking.isSelfConnection(_fullPortReference),
+          ),
         );
         dstLowIndex += element.width;
       }
@@ -556,7 +574,7 @@ class ConnectionExtractor {
             dstLowIndex: 0,
             dstHighIndex: load.width - 1,
             dstDimensionAccess: const []),
-      ).whereNot((e) => e.isSelfConnection()).toList();
+      ).whereNot((e) => e.isSelfConnection(_fullPortReference)).toList();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,5 @@ dependencies:
   rohd: ^0.6.10
 
 dev_dependencies:
+  benchmark_harness: ^2.2.0
   test: ^1.16.0

--- a/test/benchmark_test.dart
+++ b/test/benchmark_test.dart
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// benchmark_test.dart
+// Smoke tests for benchmarks.
+//
+// 2026 August 20
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:test/test.dart';
+
+import '../benchmark/connection_extractor_benchmark.dart';
+
+void main() {
+  group('benchmark', tags: 'benchmark', () {
+    late ConnectionExtractorBenchmarkDesign design;
+
+    setUpAll(() async {
+      design = ConnectionExtractorBenchmarkDesign(
+        modulePairs: 2,
+        interfacesPerPair: 2,
+        portsPerDirection: 3,
+        adHocConnectionsPerPair: 4,
+      );
+      await design.top.build();
+      design.validateStructure();
+    });
+
+    test('connection extractor interface-aware', () {
+      final benchmark = ConnectionExtractorBenchmark(
+        design.modules,
+        includeInterfaceConnections: true,
+        expectedConnectionCount: design.expectedCompactConnectionCount,
+      )..run();
+
+      expect(
+        benchmark.latestConnections,
+        hasLength(design.expectedCompactConnectionCount),
+      );
+    });
+
+    test('connection extractor pin-only', () {
+      final benchmark = ConnectionExtractorBenchmark(
+        design.modules,
+        includeInterfaceConnections: false,
+        expectedConnectionCount: design.expectedPinConnectionCount,
+      )..run();
+
+      expect(
+        benchmark.latestConnections,
+        hasLength(design.expectedPinConnectionCount),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description & Motivation

Improves `ConnectionExtractor` performance by optimizing connection tracing, interface discovery, and port-reference conversion.

- Replaces the collision-prone `_ConnectionSliceTracking.hashCode` implementation with `Object.hash`.
- Caches interface port references and completeness results for each extraction.
- Indexes physical ports covered by complete interface connections.
- Caches canonical full-port `PortReference` values by `Logic` identity for each extraction.
- Reuses cached references for source, destination, self-connection, and interface-membership checks.
- Adds a synthetic `benchmark_harness` benchmark modeled after the main ROHD repository's benchmark infrastructure.
- Adds benchmark smoke tests and structural correctness guards without asserting wall-clock timing.

The benchmark uses only public ROHD and ROHD Bridge APIs. Its default configuration validates 64 child modules, 9,248 physical ports, 2,208 interface-aware connections, and 4,608 pin-only connections.

On Dart 3.13.0, the default benchmark improved as follows:

| Extraction | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Interface-aware | 17.493s | 1.154s | 93.4% |
| Pin-only | 11.734s | 0.462s | 96.1% |
| Combined | 29.227s | 1.616s | 94.5% |

Absolute timings vary by machine and runtime, so the benchmark is intended for relative before-and-after comparison.

## Related Issue(s)

None.

## Testing

- `dart test test/connection_extractor_test.dart test/benchmark_test.dart`: all 37 focused tests passed
- `dart test`: all 2,616 tests passed
- `dart analyze --fatal-infos`: no issues found
- `tool/gh_actions/verify_formatting.sh`: passed
- `dart run benchmark/benchmark.dart`: completed with all structural correctness guards passing
- Existing exact connection-set tests cover structured ports, arrays, slices, swizzles, nets, tie-offs, and hierarchy

## Backwards-compatibility

This is not a breaking change. No public APIs or extraction result formats are changed. All caches are private to one `ConnectionExtractor` instance and follow its existing construction-time snapshot semantics.

## Documentation

Added `benchmark/README.md` with benchmark commands, workload details, expected structural results, and guidance against absolute timing assertions. Updated the changelog to describe the performance improvements and benchmark coverage.