### PR TITLE
Fix hierarchical port reuse for repeated `connectPorts` fan-out

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -866,6 +866,11 @@ class BridgeModule extends Module with SystemVerilog {
   /// names are requested.
   final Map<PortReference, Map<String?, PortReference>> _punchedUpPorts = {};
 
+  /// Finds a route from [source] compatible with [requestedName].
+  ///
+  /// An unnamed request prefers an unnamed route, then any existing route. A
+  /// named request requires an exact entry or an unnamed route whose effective
+  /// port name matches [requestedName].
   PortReference? _findNamedRoute(
     Map<PortReference, Map<String?, PortReference>> routes,
     PortReference source,
@@ -892,6 +897,8 @@ class BridgeModule extends Module with SystemVerilog {
         : null;
   }
 
+  /// Whether [route] uses [name] logically, physically, or through a port
+  /// mapping.
   bool _routeUsesPortName(PortReference route, String name) =>
       route.portName == name ||
       route.port.name == name ||
@@ -901,6 +908,9 @@ class BridgeModule extends Module with SystemVerilog {
               (portMap.port.portName == name ||
                   portMap.port.port.name == name)));
 
+  /// Records a named route from [source] to [destination].
+  ///
+  /// Existing entries are retained unless [replace] is `true`.
   void _recordNamedRoute(
     Map<PortReference, Map<String?, PortReference>> routes,
     PortReference source,
@@ -916,19 +926,26 @@ class BridgeModule extends Module with SystemVerilog {
     }
   }
 
+  /// Finds a receiver-side port reached from [source] using [requestedName].
   PortReference? _findUpperSourcePort(
           PortReference source, String? requestedName) =>
       _findNamedRoute(_upperSourceMap, source, requestedName);
 
+  /// Records the current receiver-side port reached from [source].
+  ///
+  /// A later registration replaces the previous destination for the same
+  /// source and requested name as the receiver path is extended.
   void _recordUpperSourcePort(PortReference source, PortReference destination,
           {String? requestedName}) =>
       _recordNamedRoute(_upperSourceMap, source, destination,
           requestedName: requestedName, replace: true);
 
+  /// Finds a driver-side port punched up from [source].
   PortReference? _findPunchedUpPort(
           PortReference source, String? requestedName) =>
       _findNamedRoute(_punchedUpPorts, source, requestedName);
 
+  /// Records the first driver-side port punched up from [source] for a name.
   void _recordPunchedUpPort(PortReference source, PortReference destination,
           {String? requestedName}) =>
       _recordNamedRoute(_punchedUpPorts, source, destination,

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -694,8 +694,10 @@ class BridgeModule extends Module with SystemVerilog {
           if (exceptPorts != null && exceptPorts.contains(portName)) {
             continue;
           }
-          createdInterface.module._upperSourceMap[newIntf.port(portName)] =
-              createdInterface.port(portName);
+          createdInterface.module._recordUpperSourcePort(
+            newIntf.port(portName),
+            createdInterface.port(portName),
+          );
         }
       }
     }
@@ -705,8 +707,10 @@ class BridgeModule extends Module with SystemVerilog {
 
       for (final createdInterface in createdInterfaces) {
         for (final portName in interfaceInputPortNames) {
-          createdInterface.module._upperSourceMap[topToConnect.port(portName)] =
-              createdInterface.port(portName);
+          createdInterface.module._recordUpperSourcePort(
+            topToConnect.port(portName),
+            createdInterface.port(portName),
+          );
         }
       }
     }
@@ -850,13 +854,85 @@ class BridgeModule extends Module with SystemVerilog {
 
   /// Internal tracking map for hierarchical port connectivity optimization.
   ///
-  /// This map maintains a lookup table from [PortReference] objects at parent
-  /// hierarchy levels to corresponding [PortReference] objects in this module
-  /// that are driven by them. It enables efficient path reuse during complex
-  /// hierarchical connections, avoiding redundant port creation when
-  /// connections to the same driver already exist at different hierarchy
-  /// levels.
-  final Map<PortReference, PortReference> _upperSourceMap = {};
+  /// Receiver-side routes from ports above this module to local ports.
+  ///
+  /// Each source can have multiple routes when different explicit path names
+  /// are requested.
+  final Map<PortReference, Map<String?, PortReference>> _upperSourceMap = {};
+
+  /// Driver-side ports punched onto this module from one level down.
+  ///
+  /// Each lower port can have multiple aliases when different explicit path
+  /// names are requested.
+  final Map<PortReference, Map<String?, PortReference>> _punchedUpPorts = {};
+
+  PortReference? _findNamedRoute(
+    Map<PortReference, Map<String?, PortReference>> routes,
+    PortReference source,
+    String? requestedName,
+  ) {
+    final sourceRoutes = routes[source];
+    if (sourceRoutes == null || sourceRoutes.isEmpty) {
+      return null;
+    }
+
+    if (requestedName == null) {
+      return sourceRoutes[null] ?? sourceRoutes.values.first;
+    }
+
+    final exactRoute = sourceRoutes[requestedName];
+    if (exactRoute != null) {
+      return exactRoute;
+    }
+
+    final unnamedRoute = sourceRoutes[null];
+    return unnamedRoute != null &&
+            _routeUsesPortName(unnamedRoute, requestedName)
+        ? unnamedRoute
+        : null;
+  }
+
+  bool _routeUsesPortName(PortReference route, String name) =>
+      route.portName == name ||
+      route.port.name == name ||
+      (route is InterfacePortReference &&
+          route.interfaceReference.portMaps.any((portMap) =>
+              portMap.interfacePort == route &&
+              (portMap.port.portName == name ||
+                  portMap.port.port.name == name)));
+
+  void _recordNamedRoute(
+    Map<PortReference, Map<String?, PortReference>> routes,
+    PortReference source,
+    PortReference destination, {
+    String? requestedName,
+    bool replace = false,
+  }) {
+    final sourceRoutes = routes.putIfAbsent(source, () => {});
+    if (replace) {
+      sourceRoutes[requestedName] = destination;
+    } else {
+      sourceRoutes.putIfAbsent(requestedName, () => destination);
+    }
+  }
+
+  PortReference? _findUpperSourcePort(
+          PortReference source, String? requestedName) =>
+      _findNamedRoute(_upperSourceMap, source, requestedName);
+
+  void _recordUpperSourcePort(PortReference source, PortReference destination,
+          {String? requestedName}) =>
+      _recordNamedRoute(_upperSourceMap, source, destination,
+          requestedName: requestedName, replace: true);
+
+  PortReference? _findPunchedUpPort(
+          PortReference source, String? requestedName) =>
+      _findNamedRoute(_punchedUpPorts, source, requestedName);
+
+  void _recordPunchedUpPort(PortReference source, PortReference destination,
+          {String? requestedName}) =>
+      _recordNamedRoute(_punchedUpPorts, source, destination,
+          requestedName: requestedName);
 
   /// Creates a new port with the specified characteristics.
   ///
@@ -1239,7 +1315,9 @@ class BridgeModule extends Module with SystemVerilog {
 /// [allowDriverPathUniquification] or [allowReceiverPathUniquification] are
 /// `false`, then the port names will not be uniquified on those paths.
 /// Uniquification also respects [BridgeModule.allowUniquification] at each
-/// level.
+/// level. Repeated connections for the same signal reuse compatible existing
+/// hierarchy routes. A different explicitly requested path name creates a
+/// distinct alias, while an omitted path name may reuse any existing route.
 ///
 /// When [driver] and [receiver] are on the same module and the connection is
 /// ambiguous (at least one port is [PortDirection.inOut] and neither is
@@ -1267,6 +1345,9 @@ void connectPorts(
   if (driver.module.hasBuilt || receiver.module.hasBuilt) {
     throw RohdBridgeException('Cannot connect ports after build.');
   }
+
+  final explicitDriverPathName = driverPathNewPortName;
+  final explicitReceiverPathName = receiverPathNewPortName;
 
   final driverInstance = driver.module;
   final receiverInstance = receiver.module;
@@ -1335,15 +1416,30 @@ void connectPorts(
 
     for (var i = driverPath.length - 2; i >= 1; i--) {
       final driverPathI = driverPath[i] as BridgeModule;
+      final existingPort = driverPathI._findPunchedUpPort(
+        driverPortRef,
+        explicitDriverPathName,
+      );
+      if (existingPort != null) {
+        driverPortRef = existingPort;
+        continue;
+      }
+
       final uniqName = driverPathI._getUniquePortName(
         driverPortRef,
         initialName: driverPathNewPortName,
         allowNameUniquification: allowDriverPathUniquification,
       );
 
-      driverPortRef = driverPortRef.punchUpTo(
+      final lowerPortRef = driverPortRef;
+      driverPortRef = lowerPortRef.punchUpTo(
         driverPathI,
         newPortName: uniqName,
+      );
+      driverPathI._recordPunchedUpPort(
+        lowerPortRef,
+        driverPortRef,
+        requestedName: explicitDriverPathName,
       );
     }
   }
@@ -1354,6 +1450,16 @@ void connectPorts(
   // keep track of all created receiver ports so far so we can update
   // the corresponding modules' [_upperSourceMap]s
   final createdReceiverPorts = <PortReference>[];
+
+  void recordReceiverPathToDriver() {
+    for (final createdReceiverPort in [receiver, ...createdReceiverPorts]) {
+      createdReceiverPort.module._recordUpperSourcePort(
+        driverPortRef,
+        createdReceiverPort,
+        requestedName: explicitReceiverPathName,
+      );
+    }
+  }
 
   if (receiverInstance != commonParent) {
     // we need to punch upwards from the receiver to the common parent
@@ -1376,17 +1482,21 @@ void connectPorts(
         final upperTarg = upperTargets[upperTargIdx];
         final upperTargTargs = receiverPath
             .getRange(1, i + 1)
-            .map((receiverPathMod) =>
-                (receiverPathMod as BridgeModule)._upperSourceMap[upperTarg])
+            .map((receiverPathMod) => (receiverPathMod as BridgeModule)
+                ._findUpperSourcePort(upperTarg, explicitReceiverPathName))
             .nonNulls;
 
         for (final iterUpperTargi in upperTargTargs) {
-          if (receiverPathI._upperSourceMap.containsKey(iterUpperTargi)) {
+          final existingPort = receiverPathI._findUpperSourcePort(
+            iterUpperTargi,
+            explicitReceiverPathName,
+          );
+          if (existingPort != null) {
             // if we already have a known connection up to the driver from
             // here, then we can just connect to the existing port and exit
             // immediately
-            receiverPortRef
-                .gets(receiverPathI._upperSourceMap[iterUpperTargi]!);
+            receiverPortRef.gets(existingPort);
+            recordReceiverPathToDriver();
             return;
           }
 
@@ -1409,24 +1519,37 @@ void connectPorts(
       // receiver port via the port that was created.
       for (final createdReceiverPort in createdReceiverPorts) {
         final receiverPortModule = createdReceiverPort.module;
-        assert(!receiverPortModule._upperSourceMap.containsKey(receiverPortRef),
+        assert(
+            receiverPortModule._findUpperSourcePort(
+                    receiverPortRef, explicitReceiverPathName) ==
+                null,
             'should not be recreating a path if one already exists.');
-        receiverPortModule._upperSourceMap[receiverPortRef] =
-            createdReceiverPort;
+        receiverPortModule._recordUpperSourcePort(
+          receiverPortRef,
+          createdReceiverPort,
+          requestedName: explicitReceiverPathName,
+        );
       }
     }
   }
 
   // also notify about the top-level driver
-  for (final createdReceiverPort in [receiver, ...createdReceiverPorts]) {
-    final receiverPortModule = createdReceiverPort.module;
-
-    receiverPortModule._upperSourceMap[driverPortRef] = createdReceiverPort;
-  }
+  recordReceiverPathToDriver();
 
   receiverPortRef.gets(driverPortRef,
       sameModuleConnectionType: sameModuleConnectionType,
       intermediateSignalName: intermediateSignalName);
+
+  if (receiverInstance == commonParent &&
+      driverPortRef.module != commonParent &&
+      driverPortRef.direction == receiverPortRef.direction &&
+      driverPortRef.width == receiverPortRef.width) {
+    commonParent._recordPunchedUpPort(
+      driverPortRef,
+      receiverPortRef,
+      requestedName: explicitDriverPathName,
+    );
+  }
 }
 
 /// Connects [intf1] to [intf2], creating all necessary ports through the

--- a/test/port_merge_test.dart
+++ b/test/port_merge_test.dart
@@ -47,6 +47,440 @@ void main() {
       expect(leaf1.input('myPort').value.toInt(), 1);
     });
 
+    test('nested fan-out reuses explicitly named path ports', () async {
+      final source = BridgeModule('source')..addOutput('x');
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+
+      final sourceParent = BridgeModule('sourceParent')..addSubModule(source);
+      final destinationParent = BridgeModule('destinationParent')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2);
+
+      final top = BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(destinationParent);
+
+      sourceParent.addInput('clk', null);
+      top.pullUpPort(sourceParent.port('clk'), newPortName: 'clk');
+
+      connectPorts(source.port('x'), destination1.port('a'),
+          receiverPathNewPortName: 'x',
+          allowDriverPathUniquification: false,
+          allowReceiverPathUniquification: false);
+      connectPorts(source.port('x'), destination2.port('b'),
+          receiverPathNewPortName: 'x',
+          allowDriverPathUniquification: false,
+          allowReceiverPathUniquification: false);
+
+      expect(sourceParent.outputs.keys, ['source_x']);
+      expect(destinationParent.inputs.keys, ['x']);
+
+      await top.build();
+
+      source.output('x').put(1);
+      expect(destination1.input('a').value.toInt(), 1);
+      expect(destination2.input('b').value.toInt(), 1);
+    });
+
+    test('fan-out extends an existing direct parent route', () async {
+      final source = BridgeModule('source')..addOutput('x');
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+      final destination3 = BridgeModule('destination3')..addInput('c', null);
+
+      final sourceParent = BridgeModule('sourceParent')
+        ..addSubModule(source)
+        ..addOutput('x');
+      final destinationParent = BridgeModule('destinationParent')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2)
+        ..addSubModule(destination3);
+
+      final top = BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(destinationParent);
+
+      sourceParent.addInput('clk', null);
+      top.pullUpPort(sourceParent.port('clk'), newPortName: 'clk');
+
+      connectPorts(source.port('x'), sourceParent.port('x'));
+      connectPorts(source.port('x'), destination1.port('a'),
+          driverPathNewPortName: 'x', receiverPathNewPortName: 'x');
+      connectPorts(source.port('x'), destination2.port('b'),
+          driverPathNewPortName: 'alternate',
+          receiverPathNewPortName: 'alternate');
+      connectPorts(source.port('x'), destination3.port('c'),
+          driverPathNewPortName: 'x', receiverPathNewPortName: 'x');
+
+      expect(sourceParent.outputs.keys, ['x', 'alternate']);
+      expect(destinationParent.inputs.keys, ['x', 'alternate']);
+
+      await top.build();
+
+      source.output('x').put(1);
+      expect(sourceParent.output('x').value.toInt(), 1);
+      expect(sourceParent.output('alternate').value.toInt(), 1);
+      expect(destination1.input('a').value.toInt(), 1);
+      expect(destination2.input('b').value.toInt(), 1);
+      expect(destination3.input('c').value.toInt(), 1);
+    });
+
+    test('fan-out keeps differently named driver paths distinct', () {
+      final source = BridgeModule('source')..addOutput('x');
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+
+      final sourceParent = BridgeModule('sourceParent')..addSubModule(source);
+      final destinationParent1 = BridgeModule('destinationParent1')
+        ..addSubModule(destination1);
+      final destinationParent2 = BridgeModule('destinationParent2')
+        ..addSubModule(destination2);
+
+      BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(destinationParent1)
+        ..addSubModule(destinationParent2);
+
+      connectPorts(source.port('x'), destination1.port('a'),
+          driverPathNewPortName: 'first');
+      connectPorts(source.port('x'), destination2.port('b'),
+          driverPathNewPortName: 'second');
+
+      expect(sourceParent.outputs.keys, ['first', 'second']);
+    });
+
+    test('fan-out keeps differently named receiver paths distinct', () {
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+      final destinationParent = BridgeModule('destinationParent')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2);
+
+      final top = BridgeModule('top')
+        ..addInput('x', null)
+        ..addSubModule(destinationParent);
+
+      connectPorts(top.port('x'), destination1.port('a'),
+          receiverPathNewPortName: 'first');
+      connectPorts(top.port('x'), destination2.port('b'),
+          receiverPathNewPortName: 'second');
+
+      expect(destinationParent.inputs.keys, ['first', 'second']);
+    });
+
+    group('path name ordering', () {
+      final driverCases =
+          <({String description, List<String?> names, List<String> expected})>[
+        (
+          description: 'same explicit driver name',
+          names: ['lane', 'lane'],
+          expected: ['lane']
+        ),
+        (
+          description: 'driver alias is reused after another alias',
+          names: ['first', 'second', 'first'],
+          expected: ['first', 'second']
+        ),
+        (
+          description: 'unnamed driver then matching explicit name',
+          names: [null, 'source_x'],
+          expected: ['source_x']
+        ),
+        (
+          description: 'unnamed driver then different explicit name',
+          names: [null, 'routeAlias'],
+          expected: ['source_x', 'routeAlias']
+        ),
+        (
+          description: 'explicit driver then unnamed request',
+          names: ['routeAlias', null],
+          expected: ['routeAlias']
+        ),
+      ];
+
+      for (final testCase in driverCases) {
+        test(testCase.description, () {
+          final source = BridgeModule('source')..addOutput('x');
+          final sourceParent = BridgeModule('sourceParent')
+            ..addSubModule(source);
+
+          final top = BridgeModule('top')..addSubModule(sourceParent);
+          for (var i = 0; i < testCase.names.length; i++) {
+            final destination = BridgeModule('destination$i')
+              ..addInput('dataIn', null);
+            final destinationParent = BridgeModule('destinationParent$i')
+              ..addSubModule(destination);
+            top.addSubModule(destinationParent);
+
+            connectPorts(source.port('x'), destination.port('dataIn'),
+                driverPathNewPortName: testCase.names[i]);
+          }
+
+          expect(sourceParent.outputs.keys, testCase.expected);
+        });
+      }
+
+      final receiverCases =
+          <({String description, List<String?> names, List<String> expected})>[
+        (
+          description: 'same explicit receiver name',
+          names: ['lane', 'lane'],
+          expected: ['lane']
+        ),
+        (
+          description: 'receiver alias is reused after another alias',
+          names: ['first', 'second', 'first'],
+          expected: ['first', 'second']
+        ),
+        (
+          description: 'unnamed receiver then matching explicit name',
+          names: [null, 'destination0_dataIn'],
+          expected: ['destination0_dataIn']
+        ),
+        (
+          description: 'unnamed receiver then different explicit name',
+          names: [null, 'routeAlias'],
+          expected: ['destination0_dataIn', 'routeAlias']
+        ),
+        (
+          description: 'explicit receiver then unnamed request',
+          names: ['routeAlias', null],
+          expected: ['routeAlias']
+        ),
+      ];
+
+      for (final testCase in receiverCases) {
+        test(testCase.description, () {
+          final destinationParent = BridgeModule('destinationParent');
+          final top = BridgeModule('top')
+            ..addInput('x', null)
+            ..addSubModule(destinationParent);
+
+          for (var i = 0; i < testCase.names.length; i++) {
+            final destination = BridgeModule('destination$i')
+              ..addInput('dataIn', null);
+            destinationParent.addSubModule(destination);
+
+            connectPorts(top.port('x'), destination.port('dataIn'),
+                receiverPathNewPortName: testCase.names[i]);
+          }
+
+          expect(destinationParent.inputs.keys, testCase.expected);
+        });
+      }
+    });
+
+    group('driver and receiver path name cross-product', () {
+      final testCases = <({
+        String description,
+        String secondDriverName,
+        String secondReceiverName,
+        List<String> expectedDriverNames,
+        List<String> expectedReceiverNames,
+      })>[
+        (
+          description: 'same driver and receiver names merge',
+          secondDriverName: 'driver',
+          secondReceiverName: 'receiver',
+          expectedDriverNames: ['driver'],
+          expectedReceiverNames: ['receiver'],
+        ),
+        (
+          description:
+              'same driver and different receiver names split receiver path',
+          secondDriverName: 'driver',
+          secondReceiverName: 'receiver2',
+          expectedDriverNames: ['driver'],
+          expectedReceiverNames: ['receiver', 'receiver2'],
+        ),
+        (
+          description:
+              'different driver and same receiver names split both paths',
+          secondDriverName: 'driver2',
+          secondReceiverName: 'receiver',
+          expectedDriverNames: ['driver', 'driver2'],
+          expectedReceiverNames: ['receiver', 'receiver_0'],
+        ),
+        (
+          description: 'different driver and receiver names split both paths',
+          secondDriverName: 'driver2',
+          secondReceiverName: 'receiver2',
+          expectedDriverNames: ['driver', 'driver2'],
+          expectedReceiverNames: ['receiver', 'receiver2'],
+        ),
+      ];
+
+      for (final testCase in testCases) {
+        test(testCase.description, () {
+          final source = BridgeModule('source')..addOutput('x');
+          final destination1 = BridgeModule('destination1')
+            ..addInput('a', null);
+          final destination2 = BridgeModule('destination2')
+            ..addInput('b', null);
+          final sourceParent = BridgeModule('sourceParent')
+            ..addSubModule(source);
+          final destinationParent = BridgeModule('destinationParent')
+            ..addSubModule(destination1)
+            ..addSubModule(destination2);
+
+          BridgeModule('top')
+            ..addSubModule(sourceParent)
+            ..addSubModule(destinationParent);
+
+          connectPorts(source.port('x'), destination1.port('a'),
+              driverPathNewPortName: 'driver',
+              receiverPathNewPortName: 'receiver');
+          connectPorts(source.port('x'), destination2.port('b'),
+              driverPathNewPortName: testCase.secondDriverName,
+              receiverPathNewPortName: testCase.secondReceiverName);
+
+          expect(sourceParent.outputs.keys, testCase.expectedDriverNames);
+          expect(destinationParent.inputs.keys, testCase.expectedReceiverNames);
+        });
+      }
+    });
+
+    test('distinct driver route respects disabled receiver uniquification', () {
+      final source = BridgeModule('source')..addOutput('x');
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+      final sourceParent = BridgeModule('sourceParent')..addSubModule(source);
+      final destinationParent = BridgeModule('destinationParent')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2);
+
+      BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(destinationParent);
+
+      connectPorts(source.port('x'), destination1.port('a'),
+          driverPathNewPortName: 'driver1',
+          receiverPathNewPortName: 'receiver',
+          allowReceiverPathUniquification: false);
+
+      expect(
+          () => connectPorts(source.port('x'), destination2.port('b'),
+              driverPathNewPortName: 'driver2',
+              receiverPathNewPortName: 'receiver',
+              allowReceiverPathUniquification: false),
+          throwsException);
+    });
+
+    test('partial receiver route extension is reused by later fan-out', () {
+      final destination1 = BridgeModule('destination1')..addInput('a', null);
+      final destination2 = BridgeModule('destination2')..addInput('b', null);
+      final destination3 = BridgeModule('destination3')..addInput('c', null);
+      final lowerBranch = BridgeModule('lowerBranch')
+        ..addSubModule(destination2)
+        ..addSubModule(destination3);
+      final destinationInner = BridgeModule('destinationInner')
+        ..addSubModule(destination1)
+        ..addSubModule(lowerBranch);
+      final destinationOuter = BridgeModule('destinationOuter')
+        ..addSubModule(destinationInner);
+      final top = BridgeModule('top')
+        ..addInput('x', null)
+        ..addSubModule(destinationOuter);
+
+      for (final destination in [destination1, destination2, destination3]) {
+        connectPorts(
+            top.port('x'), destination.port(destination.inputs.keys.single),
+            receiverPathNewPortName: 'lane');
+      }
+
+      expect(destinationOuter.inputs.keys, ['lane']);
+      expect(destinationInner.inputs.keys, ['lane']);
+      expect(lowerBranch.inputs.keys, ['lane']);
+    });
+
+    test('multi-level fan-out distinguishes exact and different slices',
+        () async {
+      final source = BridgeModule('source')
+        ..createPort('bus', PortDirection.output, width: 8);
+      final destination1 = BridgeModule('destination1')
+        ..createPort('a', PortDirection.input, width: 4);
+      final destination2 = BridgeModule('destination2')
+        ..createPort('b', PortDirection.input, width: 4);
+      final destination3 = BridgeModule('destination3')
+        ..createPort('c', PortDirection.input, width: 4);
+
+      final sourceInner = BridgeModule('sourceInner')..addSubModule(source);
+      final sourceOuter = BridgeModule('sourceOuter')
+        ..addSubModule(sourceInner);
+      final destinationInner = BridgeModule('destinationInner')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2)
+        ..addSubModule(destination3);
+      final destinationOuter = BridgeModule('destinationOuter')
+        ..addSubModule(destinationInner);
+
+      final top = BridgeModule('top')
+        ..addSubModule(sourceOuter)
+        ..addSubModule(destinationOuter);
+
+      sourceOuter.addInput('clk', null);
+      top.pullUpPort(sourceOuter.port('clk'), newPortName: 'clk');
+
+      void connect(PortReference sourcePort, PortReference destinationPort) {
+        connectPorts(sourcePort, destinationPort,
+            driverPathNewPortName: 'lane', receiverPathNewPortName: 'lane');
+      }
+
+      connect(source.port('bus[3:0]'), destination1.port('a'));
+      connect(source.port('bus[3:0]'), destination2.port('b'));
+      connect(source.port('bus[7:4]'), destination3.port('c'));
+
+      for (final module in [sourceInner, sourceOuter]) {
+        expect(module.outputs.keys, ['lane', 'lane_0']);
+      }
+      for (final module in [destinationInner, destinationOuter]) {
+        expect(module.inputs.keys, ['lane', 'lane_0']);
+      }
+
+      await top.build();
+
+      source.output('bus').put(0xa5);
+      expect(destination1.input('a').value.toInt(), 0x5);
+      expect(destination2.input('b').value.toInt(), 0x5);
+      expect(destination3.input('c').value.toInt(), 0xa);
+    });
+
+    test('nested inout source fan-out reuses named receiver path', () async {
+      final source = BridgeModule('source')
+        ..createPort('io', PortDirection.inOut, width: 2);
+      final destination1 = BridgeModule('destination1')
+        ..createPort('a', PortDirection.input, width: 2);
+      final destination2 = BridgeModule('destination2')
+        ..createPort('b', PortDirection.input, width: 2);
+
+      final sourceParent = BridgeModule('sourceParent')..addSubModule(source);
+      final destinationParent = BridgeModule('destinationParent')
+        ..addSubModule(destination1)
+        ..addSubModule(destination2);
+
+      final top = BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(destinationParent);
+
+      sourceParent.addInput('clk', null);
+      top.pullUpPort(sourceParent.port('clk'), newPortName: 'clk');
+
+      connectPorts(source.port('io'), destination1.port('a'),
+          receiverPathNewPortName: 'io');
+      connectPorts(source.port('io'), destination2.port('b'),
+          receiverPathNewPortName: 'io');
+
+      expect(sourceParent.inOuts.keys, ['source_io']);
+      expect(destinationParent.inputs.keys, ['io']);
+
+      await top.build();
+
+      source.inOut('io').put(2);
+      expect(destination1.input('a').value.toInt(), 2);
+      expect(destination2.input('b').value.toInt(), 2);
+    });
+
     test('interleaved port merge', () async {
       final lowerLeaf = BridgeModule('lowerLeaf')..addInput('myPort', null);
 
@@ -145,6 +579,56 @@ void main() {
   });
 
   group('interface', () {
+    test('explicit names respect interface-established receiver routes',
+        () async {
+      final matchingLeaf = BridgeModule('matchingLeaf')
+        ..addInput('matchingInput', null);
+      final aliasLeaf1 = BridgeModule('aliasLeaf1')
+        ..addInput('aliasInput1', null);
+      final aliasLeaf2 = BridgeModule('aliasLeaf2')
+        ..addInput('aliasInput2', null);
+      final matchingMid = BridgeModule('matchingMid')
+        ..addSubModule(matchingLeaf);
+      final aliasMid = BridgeModule('aliasMid')
+        ..addSubModule(aliasLeaf1)
+        ..addSubModule(aliasLeaf2);
+      final interfaceLeaf = BridgeModule('interfaceLeaf')
+        ..addInterface(MyPortInterface(),
+            name: 'myIntf', role: PairRole.consumer);
+      final upperMid = BridgeModule('upperMid')
+        ..addSubModule(interfaceLeaf)
+        ..addSubModule(matchingMid)
+        ..addSubModule(aliasMid);
+      final top = BridgeModule('top')
+        ..addInput('myPort', null)
+        ..addSubModule(upperMid);
+
+      upperMid.pullUpInterface(interfaceLeaf.interface('myIntf'),
+          newIntfName: 'myIntf');
+      final establishedPathName = upperMid.inputs.keys.single;
+
+      connectPorts(
+          top.port('myPort'), upperMid.interface('myIntf').port('myIntfPort'));
+      connectPorts(top.port('myPort'), matchingLeaf.port('matchingInput'),
+          receiverPathNewPortName: establishedPathName);
+      connectPorts(top.port('myPort'), aliasLeaf1.port('aliasInput1'),
+          receiverPathNewPortName: 'alternate');
+      connectPorts(top.port('myPort'), aliasLeaf2.port('aliasInput2'),
+          receiverPathNewPortName: 'alternate');
+
+      expect(upperMid.inputs.keys, [establishedPathName, 'alternate']);
+      expect(matchingMid.inputs.keys, [establishedPathName]);
+      expect(aliasMid.inputs.keys, ['alternate']);
+
+      await top.build();
+
+      top.input('myPort').put(1);
+      expect(matchingLeaf.input('matchingInput').value.toInt(), 1);
+      expect(aliasLeaf1.input('aliasInput1').value.toInt(), 1);
+      expect(aliasLeaf2.input('aliasInput2').value.toInt(), 1);
+      expect(interfaceLeaf.input('myIntf_myIntfPort').value.toInt(), 1);
+    });
+
     test('port merges with interface port through hierarchy simply', () async {
       final leafWithIntf = BridgeModule('leafWithIntf');
       final leafWithPort = BridgeModule('leafWithPort')


### PR DESCRIPTION
## Description & Motivation

Fix hierarchical `connectPorts` fan-out so repeated connections from the same signal reuse compatible ports instead of creating unnecessary uniquified ports such as `x_0` for `x`.

Track driver-side punched-up routes by source port and explicitly requested path name. Make receiver-side source routing name-aware so repeated requests for the same path name merge while different explicit names create intentional aliases. Unnamed requests remain compatible with existing routes.

Also preserve route information when a receiver path partially extends the hierarchy before joining an existing route, register direct parent connections for later reuse, and resolve physical port names for interface-backed routes.

Add coverage for same and different driver and receiver path names, named and unnamed ordering, alias reuse after another alias is created, all driver/receiver naming cross-products, strict uniquification behavior, direct parent routes, partial route extension, exact and distinct slices, inout sources, multi-level hierarchies, and interface-established routes.

## Related Issue(s)

This addresses a reported bug where repeated fan-out with the same `receiverPathNewPortName` created both `x` and `x_0` along the same hierarchy path.  Thank you to @lmilasz for reporting.

## Testing

Added and expanded tests, and existing suite covers.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No. Existing unnamed and same-name connections continue to merge. Different explicitly requested path names remain distinct aliases. The behavior change removes unintended duplicate hierarchy ports for repeated compatible routes.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

The `connectPorts` API documentation now describes compatible route reuse, distinct explicitly named aliases, and unnamed route behavior. No external documentation updates are required.