### PR TITLE
Fix intermediate signal names for same-module connections

### DIFF
--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1249,11 +1249,12 @@ class BridgeModule extends Module with SystemVerilog {
 /// (using internal-facing ports). See [PortReference.gets] for full details.
 ///
 /// If [intermediateSignalName] is provided, an intermediate signal with that
-/// name is inserted on the direct (sibling-level) segment of the connection.
-/// This gives control over the name of the net that appears in the generated
-/// SystemVerilog. When multiple receivers share the same driver and
-/// [intermediateSignalName], the same intermediate signal is reused. The name
-/// is ignored for array-typed drivers or vertical (parent/child) connections.
+/// name is inserted on the direct sibling-level segment or same-module
+/// connection. For a loopback it appears in the parent module; for a
+/// passthrough it appears inside the connected module. When connections with
+/// the same [intermediateSignalName] share a driver, or legally share a
+/// bidirectional receiver, the same intermediate signal is reused. The name is
+/// ignored for array-typed drivers or vertical (parent/child) connections.
 void connectPorts(
   PortReference driver,
   PortReference receiver, {

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -168,7 +168,7 @@ sealed class PortReference extends Reference {
   /// disambiguate.
   ///
   /// If [intermediateSignalName] is provided, an intermediate signal with that
-  /// name is inserted on sibling-level connections. See
+  /// name is inserted on sibling-level and same-module connections. See
   /// [_insertIntermediateSignalIfNeeded] for details on when the name is
   /// applied and when it is silently ignored.
   void gets(PortReference other,
@@ -351,7 +351,7 @@ sealed class PortReference extends Reference {
   ///
   /// The [intermediateSignalName], if provided, is forwarded to
   /// [_insertIntermediateSignalIfNeeded] so that a named intermediate signal
-  /// can be inserted on sibling-level connections.
+  /// can be inserted on sibling-level or same-module connections.
   @internal
   void getsInternal(PortReference other,
       {SameModuleConnectionType? sameModuleConnectionType,
@@ -360,27 +360,35 @@ sealed class PortReference extends Reference {
   /// Returns the value that should drive the receiver for a connection sourced
   /// from [driverValue], inserting a named intermediate signal when requested.
   ///
-  /// When [intermediateSignalName] is provided and this is a sibling-level
-  /// connection whose [driverValue] is a simple (non-array) [Logic], this
-  /// creates a [Naming.renameable] intermediate signal (a [LogicNet] for
-  /// bidirectional connections, otherwise a [Logic]) driven by [driverValue]
-  /// and returns it, so the requested name appears in the generated
-  /// SystemVerilog. The width of the signal matches [driverValue], which for a
-  /// sliced driver is the width of the slice.
+  /// When [intermediateSignalName] is provided and this is a sibling-level or
+  /// same-module connection whose [driverValue] is a simple (non-array)
+  /// [Logic], this creates a [Naming.renameable] intermediate signal (a
+  /// [LogicNet] for bidirectional connections, otherwise a [Logic]) driven by
+  /// [driverValue] and returns it, so the requested name appears in the
+  /// generated SystemVerilog. The width of the signal matches [driverValue],
+  /// which for a sliced driver is the width of the slice.
   ///
   /// If a signal with the same name already exists on the same [driverValue]
-  /// (fan-out), it is reused so multiple receivers share a single signal.
+  /// (fan-out), it is reused so multiple receivers share a single signal. A
+  /// named [LogicNet] already connected to [receiverValue] is also reused for
+  /// legal fan-in connections.
   ///
   /// For cases that cannot be cleanly represented by a single named signal
   /// (structured/array or list-typed drivers, or vertical connections),
   /// [driverValue] is returned unchanged and the connection remains unnamed.
-  dynamic _insertIntermediateSignalIfNeeded(dynamic driverValue,
-      String? intermediateSignalName, PortReference other) {
+  dynamic _insertIntermediateSignalIfNeeded(
+      dynamic driverValue, String? intermediateSignalName, PortReference other,
+      {Logic? receiverValue}) {
+    final relativeLocation = _relativeLocationOf(other);
+    final supportsIntermediateSignal =
+        relativeLocation == _RelativePortLocation.sameLevel ||
+            relativeLocation == _RelativePortLocation.sameModule;
+
     if (intermediateSignalName == null ||
         driverValue is! Logic ||
         driverValue is LogicArray ||
         driverValue is LogicStructure ||
-        _relativeLocationOf(other) != _RelativePortLocation.sameLevel) {
+        !supportsIntermediateSignal) {
       return driverValue;
     }
 
@@ -390,6 +398,16 @@ sealed class PortReference extends Reference {
         .firstWhereOrNull((s) => !s.isPort && s.name == intermediateSignalName);
     if (existingNet != null) {
       return existingNet;
+    }
+
+    final existingReceiverNet = receiverValue?.srcConnections.firstWhereOrNull(
+        (signal) =>
+            signal is LogicNet &&
+            signal.name == intermediateSignalName &&
+            signal.width == driverValue.width);
+    if (existingReceiverNet != null && driverValue.isNet) {
+      existingReceiverNet <= driverValue;
+      return existingReceiverNet;
     }
 
     final net = (driverValue.isNet || port.isNet)

--- a/lib/src/references/standard_port_reference.dart
+++ b/lib/src/references/standard_port_reference.dart
@@ -52,8 +52,11 @@ class StandardPortReference extends PortReference {
           other,
           sameModuleConnectionType: sameModuleConnectionType);
       final effectiveDriver = _insertIntermediateSignalIfNeeded(
-          driver, intermediateSignalName, other);
-      receiver <= (effectiveDriver as Logic);
+          driver, intermediateSignalName, other,
+          receiverValue: receiver);
+      if (!receiver.srcConnections.contains(effectiveDriver)) {
+        receiver <= (effectiveDriver as Logic);
+      }
     } else if (other is SlicePortReference) {
       final otherDriver = _insertIntermediateSignalIfNeeded(
           _relativeDriverSubset(other,

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -53,6 +53,48 @@ void main() {
       expect(dst.input('myPortIn').value.toInt(), equals(0xAB));
     });
 
+    test('same-module loopback uses the requested net name', () async {
+      final child = BridgeModule('child')
+        ..createPort('myPortOut', PortDirection.output, width: 8)
+        ..createPort('myPortIn', PortDirection.input, width: 8);
+      final top = BridgeModule('top')
+        ..addSubModule(child)
+        ..pullUpPort(child.createPort('dummy', PortDirection.output));
+
+      connectPorts(child.port('myPortOut'), child.port('myPortIn'),
+          intermediateSignalName: 'myLoopbackNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      expect(sv, matches(RegExp(r'logic\s*\[7:0\]\s*myLoopbackNet')));
+      expect(sv, matches(RegExp(r'\.myPortOut\s*\(\s*myLoopbackNet\s*\)')));
+      expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*myLoopbackNet\s*\)')));
+    });
+
+    test('same-module passthrough uses the requested net name', () async {
+      final child = BridgeModule('child')
+        ..createPort('myPortIn', PortDirection.input, width: 8)
+        ..createPort('myPortOut', PortDirection.output, width: 8);
+      final top = BridgeModule('top')
+        ..addSubModule(child)
+        ..pullUpPort(child.createPort('dummy', PortDirection.output));
+
+      connectPorts(child.port('myPortIn'), child.port('myPortOut'),
+          sameModuleConnectionType: SameModuleConnectionType.passthrough,
+          intermediateSignalName: 'myPassthroughNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      expect(child.internalSignals.map((signal) => signal.name),
+          contains('myPassthroughNet'));
+      expect(sv, matches(RegExp(r'logic\s*\[7:0\]\s*myPassthroughNet')));
+
+      child.input('myPortIn').put(0xAB);
+      expect(child.output('myPortOut').value.toInt(), equals(0xAB));
+    });
+
     test('net name appears in portmap for both submodules', () async {
       final (:top, :src, :dst) = _buildRig(width: 4);
 
@@ -207,6 +249,73 @@ void main() {
       expect(dst1.input('myPortIn_a').value.toInt(), equals(1));
       expect(dst2.input('myPortIn_b').value.toInt(), equals(1));
       expect(dst3.input('myPortIn_c').value.toInt(), equals(1));
+    });
+
+    test('nested fan-out reuses one named net', () async {
+      final src = BridgeModule('src');
+      final branch = BridgeModule('branch');
+      final dst1 = branch.addSubModule(BridgeModule('dst1'));
+      final dst2 = branch.addSubModule(BridgeModule('dst2'));
+
+      src.createPort('myPortOut', PortDirection.output);
+      dst1.createPort('myPortIn', PortDirection.input);
+      dst2.createPort('myPortIn', PortDirection.input);
+
+      final top = BridgeModule('top')
+        ..addSubModule(src)
+        ..addSubModule(branch)
+        ..pullUpPort(src.createPort('dummy', PortDirection.output))
+        ..pullUpPort(branch.pullUpPort(
+            dst1.createPort('dummy', PortDirection.output),
+            newPortName: 'dst1Dummy'))
+        ..pullUpPort(branch.pullUpPort(
+            dst2.createPort('dummy', PortDirection.output),
+            newPortName: 'dst2Dummy'));
+
+      connectPorts(src.port('myPortOut'), dst1.port('myPortIn'),
+          intermediateSignalName: 'myNestedSharedNet');
+      connectPorts(src.port('myPortOut'), dst2.port('myPortIn'),
+          intermediateSignalName: 'myNestedSharedNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      expect(sv, contains('myNestedSharedNet'));
+      expect(sv, isNot(contains('myNestedSharedNet_0')));
+
+      src.output('myPortOut').put(1);
+      expect(dst1.input('myPortIn').value.toInt(), equals(1));
+      expect(dst2.input('myPortIn').value.toInt(), equals(1));
+    });
+
+    test('fan-in: multiple inOut drivers share one named net', () async {
+      final top = BridgeModule('top');
+      final src1 = top.addSubModule(BridgeModule('src1'));
+      final src2 = top.addSubModule(BridgeModule('src2'));
+      final dst = top.addSubModule(BridgeModule('dst'));
+
+      src1.createPort('bus1', PortDirection.inOut, width: 4);
+      src2.createPort('bus2', PortDirection.inOut, width: 4);
+      dst.createPort('busIn', PortDirection.inOut, width: 4);
+
+      top
+        ..pullUpPort(src1.createPort('dummy', PortDirection.output))
+        ..pullUpPort(src2.createPort('dummy', PortDirection.output))
+        ..pullUpPort(dst.createPort('dummy', PortDirection.output));
+
+      connectPorts(src1.port('bus1'), dst.port('busIn'),
+          intermediateSignalName: 'mySharedInOutNet');
+      connectPorts(src2.port('bus2'), dst.port('busIn'),
+          intermediateSignalName: 'mySharedInOutNet');
+
+      await top.build();
+      final sv = top.generateSynth();
+
+      expect(sv, contains('mySharedInOutNet'));
+      expect(sv, isNot(contains('mySharedInOutNet_0')));
+      expect(sv, matches(RegExp(r'\.bus1\s*\(\s*mySharedInOutNet\s*\)')));
+      expect(sv, matches(RegExp(r'\.bus2\s*\(\s*mySharedInOutNet\s*\)')));
+      expect(sv, matches(RegExp(r'\.busIn\s*\(\s*mySharedInOutNet\s*\)')));
     });
 
     test('name collision auto-uniquifies (Naming.renameable)', () async {


### PR DESCRIPTION
## Description & Motivation

Honor `intermediateSignalName` for same-module loopback and passthrough connections.

Same-module loopbacks now generate the requested net name in the parent module, while passthrough connections generate the requested intermediate signal inside the connected module. Compatible connections that share a driver or bidirectional receiver also reuse the same named intermediate rather than generating a uniquified net.

This keeps `intermediateSignalName` behavior consistent across sibling and same-module connections.

## Related Issue(s)

None.

## Testing

- Added tests for same-module loopback and passthrough naming.
- Added tests for nested fan-out and bidirectional fan-in using a shared intermediate signal name.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No. This only changes generated signal names when `intermediateSignalName` is explicitly provided in cases where it was previously ignored or unnecessarily uniquified.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes. The API documentation for `connectPorts` and `PortReference.gets` now describes same-module intermediate signal naming, including the placement difference between loopback and passthrough connections.