### PR TITLE
Add validation for references and port maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Added non-connecting `validate` methods for references and port maps so deferred mappings can be checked before use.
+- Added non-connecting `validate` methods for references and port maps so deferred mappings can be checked before use (<https://github.com/intel/rohd-bridge/pull/66>).
 - Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions, caching repeated interface and canonical port-reference lookups, and indexing interface-covered ports. Added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Added non-connecting `validate` methods for references and port maps so deferred mappings can be checked before use.
 - Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions, caching repeated interface and canonical port-reference lookups, and indexing interface-covered ports. Added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).
 - Added typed port lookup and conversion through `TypedPortReference`, `typedPort`, `tryTypedPort`, `asTyped`, and `tryAsTyped` (<https://github.com/intel/rohd-bridge/pull/58>).

--- a/lib/src/port_map.dart
+++ b/lib/src/port_map.dart
@@ -62,11 +62,35 @@ class PortMap {
   bool maps(PortReference port, InterfacePortReference interfacePort) =>
       this.port == port && this.interfacePort == interfacePort;
 
-  /// Validates that both endpoints of this port map resolve without connecting
-  /// them.
+  /// Validates that both endpoints resolve with equal widths and an available
+  /// receiver without connecting them.
   void validate() {
     port.validate();
     interfacePort.validate();
+
+    if (port.width != interfacePort.width) {
+      throw RohdBridgeException(
+        'Port map width mismatch: $port has width ${port.width}, but '
+        '$interfacePort has width ${interfacePort.width}.',
+      );
+    }
+
+    final externalInterface = interfacePort.interfaceReference.interface;
+    final receiver = switch (port.direction) {
+      PortDirection.input when !_isConnected =>
+        port.module.inputSource(port.portName),
+      PortDirection.output when !_isConnected =>
+        externalInterface.port(interfacePort.portName),
+      PortDirection.input ||
+      PortDirection.output ||
+      PortDirection.inOut =>
+        null,
+    };
+
+    if (receiver?.srcConnection != null) {
+      throw RohdBridgeException(
+          'Port map receiver already has a source connection: $receiver');
+    }
   }
 
   /// Resolves a port map by connecting the [port] to the [interfacePort] in

--- a/lib/src/port_map.dart
+++ b/lib/src/port_map.dart
@@ -62,6 +62,13 @@ class PortMap {
   bool maps(PortReference port, InterfacePortReference interfacePort) =>
       this.port == port && this.interfacePort == interfacePort;
 
+  /// Validates that both endpoints of this port map resolve without connecting
+  /// them.
+  void validate() {
+    port.validate();
+    interfacePort.validate();
+  }
+
   /// Resolves a port map by connecting the [port] to the [interfacePort] in
   /// the appropriate direction.
   ///

--- a/lib/src/references/interface_reference.dart
+++ b/lib/src/references/interface_reference.dart
@@ -59,6 +59,14 @@ class InterfaceReference<InterfaceType extends PairInterface>
   late final List<PortMap> portMaps = UnmodifiableListView(_portMaps);
   final List<PortMap> _portMaps = [];
 
+  /// Validates all port maps owned by this interface without connecting them.
+  @override
+  void validate() {
+    for (final portMap in portMaps) {
+      portMap.validate();
+    }
+  }
+
   /// All port references that belong to this interface.
   ///
   /// Returns a list of [InterfacePortReference]s for every port defined in the

--- a/lib/src/references/port_reference.dart
+++ b/lib/src/references/port_reference.dart
@@ -71,6 +71,10 @@ sealed class PortReference extends Reference {
 
   PortReference._(super.module, this.portName);
 
+  /// Validates that this reference resolves to an existing port and subset.
+  @override
+  void validate() => portSubset;
+
   /// Creates a [PortReference] from a [BridgeModule] and a port reference
   /// string.
   ///

--- a/lib/src/references/reference.dart
+++ b/lib/src/references/reference.dart
@@ -24,4 +24,10 @@ class Reference {
 
   /// Creates a new [Reference] for the given [module].
   const Reference(this.module);
+
+  /// Validates that this reference resolves to an existing boundary element.
+  ///
+  /// Throws an [Exception] if the referenced element does not exist or the
+  /// reference is otherwise invalid.
+  void validate() {}
 }

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -110,6 +110,123 @@ void main() {
       expect(portMap.isConnected, isFalse);
     });
 
+    test('requires endpoints to have the same width', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input, width: 2);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical', 4)]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      );
+
+      expect(portMap.validate, throwsA(isA<RohdBridgeException>()));
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('compares selected subset widths', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input, width: 8);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical', 4)]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical[5:2]'),
+        interfaceReference.port('logical'),
+      );
+
+      expect(portMap.validate, returnsNormally);
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('rejects a physical input receiver with a source', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical')]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      );
+
+      module.inputSource('physical') <= Logic();
+
+      expect(portMap.validate, throwsA(isA<RohdBridgeException>()));
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('rejects an interface output receiver with a source', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.output);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical')]),
+        name: 'interface',
+        role: PairRole.provider,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      );
+
+      interfaceReference.interface.port('logical') <= Logic();
+
+      expect(portMap.validate, throwsA(isA<RohdBridgeException>()));
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('allows source connections for inout maps', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.inOut);
+      final interfaceReference = module.addInterface(
+        PairInterface(commonInOutPorts: [LogicNet.port('logical')]),
+        name: 'interface',
+        role: PairRole.provider,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      );
+
+      module.inOutSource('physical') <= LogicNet();
+
+      expect(module.inOutSource('physical').srcConnections, isNotEmpty);
+      expect(portMap.validate, returnsNormally);
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('allows the source from its own established connection', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical')]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      )
+        ..connect()
+        ..validate();
+
+      expect(module.inputSource('physical').srcConnection, isNotNull);
+      expect(portMap.isConnected, isTrue);
+    });
+
     test('interface reference validates every port map', () {
       final module = BridgeModule('dut')
         ..createPort('physicalA', PortDirection.input)

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// validation_test.dart
+// Tests for validating references and port maps.
+//
+// 2026 September 4
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('reference validation', () {
+    test('supports deferred port creation', () {
+      final module = BridgeModule('dut');
+      final reference = StandardPortReference(module, 'deferred');
+
+      expect(reference.validate, throwsA(isA<RohdBridgeException>()));
+
+      module.createPort('deferred', PortDirection.input);
+
+      expect(reference.validate, returnsNormally);
+    });
+
+    test('validates the selected port subset', () {
+      final module = BridgeModule('dut')
+        ..createPort('data', PortDirection.input, width: 4);
+      final validReference = SlicePortReference(
+        module,
+        'data',
+        sliceLowerIndex: 2,
+        sliceUpperIndex: 3,
+      );
+      final outOfRangeReference = SlicePortReference(
+        module,
+        'data',
+        sliceLowerIndex: 3,
+        sliceUpperIndex: 4,
+      );
+
+      expect(validReference.validate, returnsNormally);
+      expect(outOfRangeReference.validate, throwsA(isA<RangeError>()));
+    });
+  });
+
+  group('port map validation', () {
+    test('validates the physical port', () {
+      final module = BridgeModule('dut');
+      final interfaceReference = module.addInterface(
+        PairInterface(),
+        name: 'interface',
+        role: PairRole.provider,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        StandardPortReference(module, 'missingPhysical'),
+        StandardInterfacePortReference(
+          interfaceReference,
+          'missingLogical',
+        ),
+      );
+
+      expect(portMap.validate, throwsA(isA<RohdBridgeException>()));
+      expect(
+        interfaceReference.validate,
+        throwsA(isA<RohdBridgeException>()),
+      );
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('validates the interface port', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input);
+      final interfaceReference = module.addInterface(
+        PairInterface(),
+        name: 'interface',
+        role: PairRole.provider,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        StandardInterfacePortReference(
+          interfaceReference,
+          'missingLogical',
+        ),
+      );
+
+      expect(portMap.validate, throwsA(isA<PortDoesNotExistException>()));
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('does not connect valid endpoints', () {
+      final module = BridgeModule('dut')
+        ..createPort('physical', PortDirection.input);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical')]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final portMap = module.addPortMap(
+        module.port('physical'),
+        interfaceReference.port('logical'),
+      );
+
+      expect(portMap.validate, returnsNormally);
+      expect(interfaceReference.validate, returnsNormally);
+      expect(portMap.isConnected, isFalse);
+    });
+
+    test('interface reference validates every port map', () {
+      final module = BridgeModule('dut')
+        ..createPort('physicalA', PortDirection.input)
+        ..createPort('physicalB', PortDirection.input);
+      final interfaceReference = module.addInterface(
+        PairInterface(portsFromProvider: [Logic.port('logical')]),
+        name: 'interface',
+        role: PairRole.consumer,
+        connect: false,
+      );
+      final validPortMap = module.addPortMap(
+        module.port('physicalA'),
+        interfaceReference.port('logical'),
+      );
+      final invalidPortMap = module.addPortMap(
+        module.port('physicalB'),
+        StandardInterfacePortReference(
+          interfaceReference,
+          'missingLogical',
+        ),
+      );
+
+      expect(
+        interfaceReference.validate,
+        throwsA(isA<PortDoesNotExistException>()),
+      );
+      expect(validPortMap.isConnected, isFalse);
+      expect(invalidPortMap.isConnected, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description & Motivation

References and port maps are intentionally resolved lazily, allowing them to be created before their underlying ports exist or to remain unused. Downstream tools that inspect port maps need a way to verify these references before generating reports without connecting the mappings.

This change:

- Adds `validate()` to `Reference`.
- Validates that a `PortReference` resolves to an existing port and selected subset.
- Validates both endpoints of a `PortMap` without connecting them.
- Validates every owned port map through `InterfaceReference.validate()`.
- Preserves deferred reference and port-map behavior until validation is explicitly requested.
- Adds tests for deferred port creation, sliced references, missing physical and interface ports, multiple port maps, and non-connecting validation.

## Related Issue(s)

None.

## Testing

Existing tests plus new tests for validation.

## Backwards-compatibility

No. This is an additive API change and does not alter existing lazy resolution or connection behavior.

## Documentation

Public API documentation is included for the new `validate()` methods. The next-release changelog has also been updated.