### PR TITLE
Default `connectPorts` intermediate signal names to explicit path names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Changed `connectPorts` to default intermediate signal names to the explicitly supplied receiver path name, then driver path name, when `intermediateSignalName` is omitted. Generated RTL net names may change for explicitly named paths.
 - Added non-connecting `validate` methods for references and port maps so deferred mappings can be checked before use (<https://github.com/intel/rohd-bridge/pull/66>).
 - Improved `ConnectionExtractor` performance by reducing trace-cache hash collisions, caching repeated interface and canonical port-reference lookups, and indexing interface-covered ports. Added a synthetic benchmark for regression measurement (<https://github.com/intel/rohd-bridge/pull/62>).
 - Added `sameModuleConnectionType` to `connectInterfaces` and `InterfaceReference.connectTo` to select loopback or passthrough connections between interfaces on the same module (<https://github.com/intel/rohd-bridge/pull/59>).

--- a/lib/src/bridge_module.dart
+++ b/lib/src/bridge_module.dart
@@ -1343,13 +1343,17 @@ class BridgeModule extends Module with SystemVerilog {
 /// (using external-facing ports) or a [SameModuleConnectionType.passthrough]
 /// (using internal-facing ports). See [PortReference.gets] for full details.
 ///
-/// If [intermediateSignalName] is provided, an intermediate signal with that
-/// name is inserted on the direct sibling-level segment or same-module
-/// connection. For a loopback it appears in the parent module; for a
-/// passthrough it appears inside the connected module. When connections with
-/// the same [intermediateSignalName] share a driver, or legally share a
-/// bidirectional receiver, the same intermediate signal is reused. The name is
-/// ignored for array-typed drivers or vertical (parent/child) connections.
+/// The intermediate signal name defaults to the explicitly supplied
+/// [receiverPathNewPortName], then [driverPathNewPortName], unless overridden
+/// by [intermediateSignalName]. If all three are omitted, naming is automatic.
+/// When a name is selected, an intermediate signal with that name is inserted
+/// on the direct sibling-level segment or same-module connection. For a
+/// loopback it appears in the parent module; for a passthrough it appears
+/// inside the connected module. When connections with the same resolved name
+/// share a driver, or legally share a bidirectional receiver, the same
+/// intermediate signal is reused. Names may be uniquified on collision and
+/// are ignored for structured/array-typed drivers or vertical (parent/child)
+/// connections.
 void connectPorts(
   PortReference driver,
   PortReference receiver, {
@@ -1366,6 +1370,9 @@ void connectPorts(
 
   final explicitDriverPathName = driverPathNewPortName;
   final explicitReceiverPathName = receiverPathNewPortName;
+  final resolvedIntermediateSignalName = intermediateSignalName ??
+      explicitReceiverPathName ??
+      explicitDriverPathName;
 
   final driverInstance = driver.module;
   final receiverInstance = receiver.module;
@@ -1513,7 +1520,8 @@ void connectPorts(
             // if we already have a known connection up to the driver from
             // here, then we can just connect to the existing port and exit
             // immediately
-            receiverPortRef.gets(existingPort);
+            receiverPortRef.gets(existingPort,
+                intermediateSignalName: resolvedIntermediateSignalName);
             recordReceiverPathToDriver();
             return;
           }
@@ -1556,7 +1564,7 @@ void connectPorts(
 
   receiverPortRef.gets(driverPortRef,
       sameModuleConnectionType: sameModuleConnectionType,
-      intermediateSignalName: intermediateSignalName);
+      intermediateSignalName: resolvedIntermediateSignalName);
 
   if (receiverInstance == commonParent &&
       driverPortRef.module != commonParent &&

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -28,6 +28,149 @@ import 'package:test/test.dart';
 
 void main() {
   group('intermediateSignalName on connectPorts', () {
+    for (final names in [
+      (
+        description: 'receiver path only',
+        driver: null,
+        receiver: 'receiverWire',
+        intermediate: null,
+        expected: 'receiverWire',
+      ),
+      (
+        description: 'driver path only',
+        driver: 'driverWire',
+        receiver: null,
+        intermediate: null,
+        expected: 'driverWire',
+      ),
+      (
+        description: 'receiver path overrides driver path',
+        driver: 'driverWire',
+        receiver: 'receiverWire',
+        intermediate: null,
+        expected: 'receiverWire',
+      ),
+      (
+        description: 'explicit intermediate overrides both paths',
+        driver: 'driverWire',
+        receiver: 'receiverWire',
+        intermediate: 'explicitWire',
+        expected: 'explicitWire',
+      ),
+      (
+        description: 'no supplied names keeps the direct connection',
+        driver: null,
+        receiver: null,
+        intermediate: null,
+        expected: null,
+      ),
+    ]) {
+      test('path name fallback: ${names.description}', () async {
+        final (:top, :src, :dst) = _buildRig();
+        src.createPort('myPortOut', PortDirection.output, width: 8);
+        dst.createPort('myPortIn', PortDirection.input, width: 8);
+
+        connectPorts(src.port('myPortOut'), dst.port('myPortIn'),
+            driverPathNewPortName: names.driver,
+            receiverPathNewPortName: names.receiver,
+            intermediateSignalName: names.intermediate);
+
+        await top.build();
+        final sv = top.generateSynth();
+        if (names.expected == null) {
+          expect(dst.inputSource('myPortIn').srcConnections,
+              contains(src.output('myPortOut')));
+        } else {
+          expect(
+              sv,
+              matches(
+                  RegExp('\\.myPortOut\\s*\\(\\s*${names.expected}\\s*\\)')));
+          expect(
+              sv,
+              matches(
+                  RegExp('\\.myPortIn\\s*\\(\\s*${names.expected}\\s*\\)')));
+        }
+        expect(src.outputs.keys, contains('myPortOut'));
+        expect(dst.inputs.keys, contains('myPortIn'));
+
+        src.output('myPortOut').put(0xAB);
+        expect(dst.input('myPortIn').value.toInt(), 0xAB);
+      });
+    }
+
+    test('path name fallback: nested fan-out reuses the named route', () async {
+      final source = BridgeModule('source')
+        ..createPort('dataOut', PortDirection.output, width: 8);
+      final first = BridgeModule('first')
+        ..createPort('dataIn', PortDirection.input, width: 8);
+      final second = BridgeModule('second')
+        ..createPort('dataIn', PortDirection.input, width: 8);
+      final sourceParent = BridgeModule('sourceParent')..addSubModule(source);
+      final receiverParent = BridgeModule('receiverParent')
+        ..addSubModule(first)
+        ..addSubModule(second);
+      final top = BridgeModule('top')
+        ..addSubModule(sourceParent)
+        ..addSubModule(receiverParent)
+        ..pullUpPort(sourceParent.createPort('dummy', PortDirection.output));
+
+      for (final receiver in [first, first, second]) {
+        connectPorts(source.port('dataOut'), receiver.port('dataIn'),
+            driverPathNewPortName: 'driverRoute',
+            receiverPathNewPortName: 'receiverRoute');
+      }
+
+      await top.build();
+      final sv = top.generateSynth();
+      expect(receiverParent.inputs.keys, ['receiverRoute']);
+      expect(
+          sourceParent
+              .output('driverRoute')
+              .dstConnections
+              .where((signal) => signal.name == 'receiverRoute'),
+          hasLength(1));
+      expect(sv, isNot(contains('receiverRoute_0')));
+      expect(sv, matches(RegExp(r'\.driverRoute\s*\(\s*receiverRoute\s*\)')));
+      expect(sv, matches(RegExp(r'\.receiverRoute\s*\(\s*receiverRoute\s*\)')));
+
+      source.output('dataOut').put(0xAB);
+      expect(first.input('dataIn').value.toInt(), 0xAB);
+      expect(second.input('dataIn').value.toInt(), 0xAB);
+    });
+
+    test('path name fallback: collisions keep independent nets distinct',
+        () async {
+      final (:top, :src, :dst) = _buildRig();
+      src
+        ..createPort('firstOut', PortDirection.output, width: 8)
+        ..createPort('secondOut', PortDirection.output, width: 8);
+      dst
+        ..createPort('firstIn', PortDirection.input, width: 8)
+        ..createPort('secondIn', PortDirection.input, width: 8);
+
+      connectPorts(src.port('firstOut'), dst.port('firstIn'),
+          receiverPathNewPortName: 'sharedWire');
+      connectPorts(src.port('secondOut'), dst.port('secondIn'),
+          receiverPathNewPortName: 'sharedWire');
+
+      await top.build();
+      final sv = top.generateSynth();
+      final firstNet = RegExp(r'\.firstIn\s*\(\s*(sharedWire(?:_\d+)?)\s*\)')
+          .firstMatch(sv)!
+          .group(1)!;
+      final secondNet = RegExp(r'\.secondIn\s*\(\s*(sharedWire(?:_\d+)?)\s*\)')
+          .firstMatch(sv)!
+          .group(1)!;
+      expect(firstNet, isNot(secondNet));
+      expect(sv, matches(RegExp('\\.firstOut\\s*\\(\\s*$firstNet\\s*\\)')));
+      expect(sv, matches(RegExp('\\.secondOut\\s*\\(\\s*$secondNet\\s*\\)')));
+
+      src.output('firstOut').put(0xAB);
+      src.output('secondOut').put(0xCD);
+      expect(dst.input('firstIn').value.toInt(), 0xAB);
+      expect(dst.input('secondIn').value.toInt(), 0xCD);
+    });
+
     test('sibling logic ports: net appears by name in generated SV', () async {
       final (:top, :src, :dst) = _buildRig();
 

--- a/test/intermediate_signal_name_test.dart
+++ b/test/intermediate_signal_name_test.dart
@@ -258,6 +258,85 @@ void main() {
       expect(dst.input('myPortIn').value.toInt(), equals(0xA));
     });
 
+    for (final exportFirst in [true, false]) {
+      test(
+          'exported top port is reused as the named sibling signal '
+          '${exportFirst ? 'before' : 'after'} the sibling connection',
+          () async {
+        final top = BridgeModule('top');
+        final src = top.addSubModule(BridgeModule('src'))
+          ..createPort('myPortOut', PortDirection.output, width: 8);
+        final dst = top.addSubModule(BridgeModule('dst'))
+          ..createPort('myPortIn', PortDirection.input, width: 8);
+
+        void exportSignal() =>
+            top.pullUpPort(src.port('myPortOut'), newPortName: 'explicit_name');
+        void connectSiblings() =>
+            connectPorts(src.port('myPortOut'), dst.port('myPortIn'),
+                intermediateSignalName: 'explicit_name');
+
+        if (exportFirst) {
+          exportSignal();
+          connectSiblings();
+        } else {
+          connectSiblings();
+          exportSignal();
+        }
+
+        await top.build();
+        final sv = top.generateSynth();
+
+        expect(sv, isNot(contains('explicit_name_0')));
+        expect(sv, matches(RegExp(r'\.myPortOut\s*\(\s*explicit_name\s*\)')));
+        expect(sv, matches(RegExp(r'\.myPortIn\s*\(\s*explicit_name\s*\)')));
+
+        src.output('myPortOut').put(0xAB);
+        expect(top.output('explicit_name').value.toInt(), equals(0xAB));
+        expect(dst.input('myPortIn').value.toInt(), equals(0xAB));
+      },
+          skip: 'Pending release of ROHD PR '
+              'https://github.com/intel/rohd/pull/712');
+    }
+
+    for (final exportFirst in [true, false]) {
+      test(
+          'exported top inout is reused as the named sibling signal '
+          '${exportFirst ? 'before' : 'after'} the sibling connection',
+          () async {
+        final top = BridgeModule('top');
+        final src = top.addSubModule(BridgeModule('src'))
+          ..createPort('myPort', PortDirection.inOut, width: 8);
+        final dst = top.addSubModule(BridgeModule('dst'))
+          ..createPort('myPort', PortDirection.inOut, width: 8);
+
+        void exportSignal() =>
+            top.pullUpPort(src.port('myPort'), newPortName: 'explicit_name');
+        void connectSiblings() =>
+            connectPorts(src.port('myPort'), dst.port('myPort'),
+                intermediateSignalName: 'explicit_name');
+
+        if (exportFirst) {
+          exportSignal();
+          connectSiblings();
+        } else {
+          connectSiblings();
+          exportSignal();
+        }
+
+        await top.build();
+        final sv = top.generateSynth();
+
+        expect(sv, isNot(contains('explicit_name_0')));
+        expect(sv, matches(RegExp(r'\.myPort\s*\(\s*explicit_name\s*\)')));
+
+        src.inOut('myPort').put(0xAB);
+        expect(top.inOut('explicit_name').value.toInt(), equals(0xAB));
+        expect(dst.inOut('myPort').value.toInt(), equals(0xAB));
+      },
+          skip: 'Pending release of ROHD PR '
+              'https://github.com/intel/rohd/pull/712');
+    }
+
     test('without intermediateSignalName: connection works normally', () async {
       final (:top, :src, :dst) = _buildRig(width: 4);
 


### PR DESCRIPTION
## Description & Motivation

Make `connectPorts` use explicitly supplied path names as fallbacks for the intermediate signal name. Previously, these arguments named newly punched hierarchy ports but left the connecting net name to ROHD, which could select a raw endpoint port name instead.

The naming precedence is:

1. `intermediateSignalName`
2. Explicitly supplied `receiverPathNewPortName`
3. Explicitly supplied `driverPathNewPortName`
4. Automatic ROHD naming when all three are omitted

The resolved name is passed through both the normal connection path and the existing-route reuse path. Existing restrictions for vertical connections and structured/array-typed drivers remain unchanged.

## Related Issue(s)

Thank you to @lmilasz for reporting

## Testing

- Added seven passing regression tests covering receiver-only and driver-only fallbacks, receiver precedence, explicit intermediate-name precedence, unchanged all-null behavior, nested fan-out reuse, and independent-net collisions.
- Existing tests cover a lot

## Backwards-compatibility

No API signature changes. Calls without explicit naming arguments retain their existing behavior, and an explicit `intermediateSignalName` still takes precedence.

Generated RTL net names may change for calls that supply path names without an intermediate signal name. Consumers relying on previously auto-selected internal net names may need updates. Existing endpoint port names and functional connectivity are preserved.

## Documentation

Updated the `connectPorts` API documentation and changelog to describe the fallback order and its effect on generated RTL names.