### PR TITLE
Add hierarchyTree to pretty-print module hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+- Added `hierarchyTree` to pretty-print module hierarchy from a given module down (<https://github.com/intel/rohd-bridge/issues/5>).
+
 ## 0.2.4
 
 - Added `allowIntermediateSignalNameUniquification` to `connectPorts` and port-reference connections, defaulting to `true`. Setting it to `false` reserves the resolved intermediate name. Stricter requests can create separate aliases for new fan-out receivers and bidirectional nets while preserving existing connections; unsupported custom clones and rewiring already-connected non-net receivers are rejected (<https://github.com/intel/rohd-bridge/pull/68>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.5
 
-- Added `hierarchyTree` to pretty-print module hierarchy from a given module down (<https://github.com/intel/rohd-bridge/issues/5>).
+- Added `hierarchyTree` to pretty-print module hierarchy from a given module down (<https://github.com/intel/rohd-bridge/pull/69>).
 
 ## 0.2.4
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ myTop.findSubModules(RegExp('myUpperMid/.*/?myLeaf$'));
 
 // Find one matching module, with an exception if more than 1 matches.
 myTop.findSubModule('myLeaf');
+
+// Pretty-print the constructed hierarchy from a module down
+print(myTop.hierarchyTree());
 ```
 
 #### Port and Interface References

--- a/lib/src/module_extensions.dart
+++ b/lib/src/module_extensions.dart
@@ -10,6 +10,7 @@
 //   Shankar Sharma <shankar.sharma@intel.com>
 //   Suhas Virmani <suhas.virmani@intel.com>
 //   Max Korbel <max.korbel@intel.com>
+//   KayanoLiam <Kayano04@outlook.jp>
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_bridge/rohd_bridge.dart';
@@ -95,6 +96,78 @@ extension RohdBridgeModuleExtensions on Module {
 
   /// Provides a full hierarchical name based on [hierarchy].
   String get hierarchicalName => hierarchy().map((e) => e.name).join('.');
+
+  /// Returns a pretty-printed [String] of the hierarchy from this [Module]
+  /// down.
+  ///
+  /// Each line is an instance [name]. If [definitionName] differs from [name],
+  /// it is shown in parentheses. For [BridgeModule]s, only [BridgeModule]
+  /// children are included so the constructed design is shown both before and
+  /// after [Module.build].
+  ///
+  /// ```dart
+  /// final top = BridgeModule('top')
+  ///   ..addSubModule(
+  ///     BridgeModule('east')..addSubModule(BridgeModule('leaf')),
+  ///   )
+  ///   ..addSubModule(BridgeModule('west'));
+  /// print(top.hierarchyTree());
+  /// ```
+  ///
+  /// The example above produces:
+  ///
+  /// ```text
+  /// top
+  /// ├── east
+  /// │   └── leaf
+  /// └── west
+  /// ```
+  String hierarchyTree() {
+    final buffer = StringBuffer(_hierarchyTreeLabel);
+    final children = _hierarchyTreeChildren.toList(growable: false);
+    for (var i = 0; i < children.length; i++) {
+      buffer.writeln();
+      children[i]._writeHierarchyTree(
+        buffer,
+        prefix: '',
+        isLast: i == children.length - 1,
+      );
+    }
+    return buffer.toString();
+  }
+
+  /// Children included in [hierarchyTree].
+  Iterable<Module> get _hierarchyTreeChildren => switch (this) {
+        final BridgeModule bridgeModule => bridgeModule.subBridgeModules,
+        _ => subModules,
+      };
+
+  /// Instance label for [hierarchyTree], with [definitionName] when it differs.
+  String get _hierarchyTreeLabel =>
+      name == definitionName ? name : '$name ($definitionName)';
+
+  /// Writes this module as a tree node under [prefix] into [buffer].
+  void _writeHierarchyTree(
+    StringBuffer buffer, {
+    required String prefix,
+    required bool isLast,
+  }) {
+    buffer
+      ..write(prefix)
+      ..write(isLast ? '└── ' : '├── ')
+      ..write(_hierarchyTreeLabel);
+
+    final children = _hierarchyTreeChildren.toList(growable: false);
+    final childPrefix = '$prefix${isLast ? '    ' : '│   '}';
+    for (var i = 0; i < children.length; i++) {
+      buffer.writeln();
+      children[i]._writeHierarchyTree(
+        buffer,
+        prefix: childPrefix,
+        isLast: i == children.length - 1,
+      );
+    }
+  }
 
   /// Returns a list of instances between calling module `this` and the provided
   /// [instance], where the first element is `this` and the last element is

--- a/test/hierarchy_tree_test.dart
+++ b/test/hierarchy_tree_test.dart
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// hierarchy_tree_test.dart
+// Unit tests for pretty-printing module hierarchy.
+//
+// 2026 September 12
+// Author: KayanoLiam <Kayano04@outlook.jp>
+
+import 'package:rohd_bridge/rohd_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('single module has only its name', () {
+    expect(BridgeModule('leaf').hierarchyTree(), 'leaf');
+  });
+
+  test('tree uses box-drawing branches', () {
+    final top = BridgeModule('top')
+      ..addSubModule(
+        BridgeModule('east')..addSubModule(BridgeModule('leaf')),
+      )
+      ..addSubModule(BridgeModule('west'));
+
+    expect(
+      top.hierarchyTree(),
+      'top\n'
+      '├── east\n'
+      '│   └── leaf\n'
+      '└── west',
+    );
+  });
+
+  test('tree can start from a module below the top', () {
+    final topMod = BridgeModule('topMod')
+      ..addSubModule(
+        BridgeModule('myUpperMid')
+          ..addSubModule(
+            BridgeModule('myLowerMid')
+              ..addSubModule(BridgeModule('myLeaf'))
+              ..addSubModule(BridgeModule('myLeaf2')),
+          )
+          ..addSubModule(
+            BridgeModule('myLowerMid2')
+              ..addSubModule(BridgeModule('myLeaf'))
+              ..addSubModule(BridgeModule('myLeaf2')),
+          ),
+      );
+
+    expect(
+      topMod.findSubModule('myUpperMid')!.hierarchyTree(),
+      'myUpperMid\n'
+      '├── myLowerMid\n'
+      '│   ├── myLeaf\n'
+      '│   └── myLeaf2\n'
+      '└── myLowerMid2\n'
+      '    ├── myLeaf\n'
+      '    └── myLeaf2',
+    );
+  });
+
+  test('definition name is shown when it differs from instance name', () {
+    final top = BridgeModule('soc', name: 'u_soc')
+      ..addSubModule(BridgeModule('cpu', name: 'u_cpu'));
+
+    expect(
+      top.hierarchyTree(),
+      'u_soc (soc)\n'
+      '└── u_cpu (cpu)',
+    );
+  });
+
+  test('constructed tree is unchanged after build', () async {
+    final top = BridgeModule('top');
+    final east = top.addSubModule(BridgeModule('east'));
+    final west = top.addSubModule(BridgeModule('west'));
+
+    top.addInput('clk', null);
+    east.addInput('clk', null);
+    connectPorts(top.port('clk'), east.port('clk'));
+
+    east.addOutput('myOutput', width: 4);
+    west.addInput('myInput', null, width: 4);
+    connectPorts(east.port('myOutput'), west.port('myInput'));
+
+    const expected = 'top\n'
+        '├── east\n'
+        '└── west';
+
+    expect(top.hierarchyTree(), expected);
+
+    await top.build();
+
+    expect(top.hierarchyTree(), expected);
+  });
+}


### PR DESCRIPTION
## Description & Motivation

Sometimes it is useful to inspect the constructed design hierarchy as a pretty-printed string. ROHD's `hierarchyString` walks internal `_subModules`, so it is empty before `build` and can include non-Bridge ROHD modules afterwards.

This adds `Module.hierarchyTree()`, which returns a box-drawing tree of instance names from a given module down. For `BridgeModule`s, only `BridgeModule` children are included, so the constructed hierarchy is shown both before and after `build`. If `definitionName` differs from the instance `name`, it is shown in parentheses.

Example:

```text
top
├── east
│   └── leaf
└── west
```

## Related Issue(s)

Fixes #5

## Testing

Added `test/hierarchy_tree_test.dart` covering:

- a leaf module
- nested box-drawing branches
- starting from a module below the top
- instance vs definition names
- stability of the constructed tree after `build`

`dart analyze --fatal-infos`, `dart format`, and `dart test` all pass locally.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No. This only adds a new API.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes. Dartdoc is included on `hierarchyTree`, the README hierarchy section shows how to call it, and CHANGELOG 0.2.5 records the addition.
